### PR TITLE
ban/unban: support for offline players using SteamID

### DIFF
--- a/Essentials/Commands/PlayerModule.cs
+++ b/Essentials/Commands/PlayerModule.cs
@@ -102,6 +102,9 @@ namespace Essentials
         [Permission(MyPromoteLevel.Moderator)]
         public void Ban(string playerName)
         {
+            var multiplayerManager = Context.Torch.CurrentSession?.Managers?.GetManager<IMultiplayerManagerServer>();
+            if (multiplayerManager == null)
+                return;
             var player = Utilities.GetPlayerByNameOrId(playerName);
             var steamUserId = 0ul;
             if (player == null)
@@ -115,12 +118,12 @@ namespace Essentials
             }
             else
                 steamUserId = player.SteamUserId;
-            if (Context.Torch.Multiplayer.BannedPlayers.Contains(steamUserId))
+            if (multiplayerManager.BannedPlayers.Contains(steamUserId))
             {
                 Context.Respond("Player is already banned.");
                 return;
             }
-            Context.Torch.CurrentSession?.Managers?.GetManager<IMultiplayerManagerServer>()?.BanPlayer(steamUserId);
+            multiplayerManager.BanPlayer(steamUserId);
             Context.Respond($"Player '{player?.DisplayName ?? steamUserId.ToString()}' banned.");
         }
 
@@ -128,14 +131,17 @@ namespace Essentials
         [Permission(MyPromoteLevel.Moderator)]
         public void Unban(string steamIdStr)
         {
+            var multiplayerManager = Context.Torch.CurrentSession?.Managers?.GetManager<IMultiplayerManagerServer>();
+            if (multiplayerManager == null)
+                return;
             if (!ulong.TryParse(steamIdStr, out var steamUserId) || steamIdStr.Length != 17)
             {
                 Context.Respond($"Usage: !unban <steamID>");
                 return;
             }
-            if (Context.Torch.CurrentSession?.Managers?.GetManager<IMultiplayerManagerServer>()?.BannedPlayers.Contains(steamUserId))
+            if (multiplayerManager.BannedPlayers.Contains(steamUserId))
             {
-                Context.Torch.CurrentSession?.Managers?.GetManager<IMultiplayerManagerServer>()?.BanPlayer(steamUserId, false);
+                multiplayerManager.BanPlayer(steamUserId, false);
                 Context.Respond($"Player '{steamUserId}' unbanned.");
             }
             else

--- a/Essentials/Commands/PlayerModule.cs
+++ b/Essentials/Commands/PlayerModule.cs
@@ -103,30 +103,43 @@ namespace Essentials
         public void Ban(string playerName)
         {
             var player = Utilities.GetPlayerByNameOrId(playerName);
-            if (player != null)
+            var steamUserId = 0ul;
+            if (player == null)
             {
-                Context.Torch.Multiplayer.BanPlayer(player.SteamUserId);
-                Context.Respond($"Player '{player.DisplayName}' banned.");
+                if (!ulong.TryParse(playerName, out steamUserId) || playerName.Length != 17)
+                {
+                    Context.Respond("Player not found. Use !ban <steamID> to ban offline players.");
+                    return;
+                }
             }
             else
+                steamUserId = player.SteamUserId;
+            if (Context.Torch.Multiplayer.BannedPlayers.Contains(steamUserId))
             {
-                Context.Respond("Player not found.");
+                Context.Respond("Player is already banned.");
+                return;
             }
+            Context.Torch.Multiplayer.BanPlayer(steamUserId);
+            Context.Respond($"Player '{player?.DisplayName ?? steamUserId.ToString()}' banned.");
         }
 
         [Command("unban", "Unban a player from the game.")]
         [Permission(MyPromoteLevel.Moderator)]
-        public void Unban(string playerName)
+        public void Unban(string steamIdStr)
         {
-            var player = Utilities.GetPlayerByNameOrId(Context.Args.FirstOrDefault());
-            if (player != null)
+            if (!ulong.TryParse(steamIdStr, out var steamUserId) || steamIdStr.Length != 17)
             {
-                Context.Torch.Multiplayer.BanPlayer(player.SteamUserId, false);
-                Context.Respond($"Player '{player.DisplayName}' unbanned.");
+                Context.Respond($"Usage: !unban <steamID>");
+                return;
+            }
+            if (Context.Torch.Multiplayer.BannedPlayers.Contains(steamUserId))
+            {
+                Context.Torch.Multiplayer.BanPlayer(steamUserId, false);
+                Context.Respond($"Player '{steamUserId}' unbanned.");
             }
             else
             {
-                Context.Respond("Player not found.");
+                Context.Respond("Player is not banned.");
             }
         }
 


### PR DESCRIPTION
Solves: https://github.com/TorchAPI/Torch/issues/89

Requires: https://github.com/TorchAPI/Torch/pull/119

Changes:
- **ban** accepts playername or SteamID as before, but can handle offline SteamID's as well
- **unban** accepts SteamID only, because the banned player is never online
- both commands check if the the player/SteamID is already banned