### PR TITLE
ownedby IdentityId and NPCs

### DIFF
--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -266,6 +266,17 @@ namespace Essentials.Commands
         public bool OwnedBy(MyCubeGrid grid, string str)
         {
             long identityId;
+            
+            String digitsOnly = @"\d+";
+            
+            if (Regex.IsMatch(str, digitsOnly)){
+                try
+                {
+                    public static long tryID = ToInt64(str);
+                    if (grid.BigOwners.Contains(tryID)) return grid.BigOwners.Contains(tryID);
+                } 
+                catch {}
+            }
 
             if (string.Compare(str, "nobody", StringComparison.InvariantCultureIgnoreCase) == 0)
             {

--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -269,14 +269,15 @@ namespace Essentials.Commands
             
             String digitsOnly = @"\d+";
             
-            if (Regex.IsMatch(str, digitsOnly)){
-                try
+            try
+            {
+                if (Regex.IsMatch(str, digitsOnly) == true)
                 {
-                    public static long tryID = ToInt64(str);
-                    if (grid.BigOwners.Contains(tryID)) return grid.BigOwners.Contains(tryID);
-                } 
-                catch {}
+                    long tryID = ToInt64(str);
+                    if (grid.BigOwners.Contains(tryID) == true) return grid.BigOwners.Contains(tryID);
+                }
             }
+            catch {}
 
             if (string.Compare(str, "nobody", StringComparison.InvariantCultureIgnoreCase) == 0)
             {

--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -273,7 +273,7 @@ namespace Essentials.Commands
             {
                 if (Regex.IsMatch(str, digitsOnly) == true)
                 {
-                    long tryID = ToInt64(str);
+                    long tryID = Convert.ToInt64(str);
                     if (grid.BigOwners.Contains(tryID) == true) return grid.BigOwners.Contains(tryID);
                 }
             }


### PR DESCRIPTION
Currently the code is set up to GetPlayerByNameOrID, which doesn't appear to return the NPC entity (at least on my testing). We should allow the code to try and directly input the ID number first if it passes a simple regex.