### PR TITLE
Check for NPC on ownedby condition

### DIFF
--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -288,10 +288,7 @@ namespace Essentials.Commands
                             return grid.BigOwners.Contains(NPCId);
                         }
                     }
-                    else 
-                    {
                     return false;
-                    }
                 }
                 identityId = player.IdentityId;
             }

--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -265,7 +265,7 @@ namespace Essentials.Commands
         [Condition("ownedby", helpText: "Finds grids owned by the given player. Can specify player name, IdentityId, 'nobody', or 'pirates'.")]
         public bool OwnedBy(MyCubeGrid grid, string str)
         {
-            long identityId = null;
+            long identityId;
 
             if (string.Compare(str, "nobody", StringComparison.InvariantCultureIgnoreCase) == 0)
             {
@@ -284,15 +284,16 @@ namespace Essentials.Commands
                     if(long.TryParse(str, out long NPCId))
                     {
                         if(MySession.Static.Players.IdentityIsNpc(NPCId))
+                        {
                             return grid.BigOwners.Contains(NPCId);
+                        }
                     }
                     else 
                     {
                     return false;
                     }
-                    
-                    identityId = player.IdentityId;
                 }
+                identityId = player.IdentityId;
             }
 
             return grid.BigOwners.Contains(identityId);

--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -280,9 +280,15 @@ namespace Essentials.Commands
             {
                 var player = Utilities.GetPlayerByNameOrId(str);
                 if (player == null)
-                    return false;
-
+                {
+                    if(MySession.Static.Players.IdentityIsNpc(identityId))
+                    {
+                        return grid.BigOwners.Contains(identityId);
+                    }
+                    else return false;
+                    
                 identityId = player.IdentityId;
+                }
             }
 
             return grid.BigOwners.Contains(identityId);

--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -281,11 +281,15 @@ namespace Essentials.Commands
                 var player = Utilities.GetPlayerByNameOrId(str);
                 if (player == null)
                 {
-                    if(MySession.Static.Players.IdentityIsNpc(identityId))
+                    if(long.TryParse(str, out long NPCId))
                     {
-                        return grid.BigOwners.Contains(identityId);
+                        if(MySession.Static.Players.IdentityIsNpc(NPCId))
+                            return grid.BigOwners.Contains(NPCId);
                     }
-                    else return false;
+                    else 
+                    {
+                    return false;
+                    }
                     
                 identityId = player.IdentityId;
                 }

--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -265,7 +265,7 @@ namespace Essentials.Commands
         [Condition("ownedby", helpText: "Finds grids owned by the given player. Can specify player name, IdentityId, 'nobody', or 'pirates'.")]
         public bool OwnedBy(MyCubeGrid grid, string str)
         {
-            long identityId;
+            long identityId = null;
 
             if (string.Compare(str, "nobody", StringComparison.InvariantCultureIgnoreCase) == 0)
             {
@@ -291,7 +291,7 @@ namespace Essentials.Commands
                     return false;
                     }
                     
-                identityId = player.IdentityId;
+                    identityId = player.IdentityId;
                 }
             }
 


### PR DESCRIPTION
Added a check to Keen's mysterious NPC Identity list, since NPCs cannot be found with MySession.Static.Players.TryGetPlayerById