### PR TITLE
Added a few more convenience commands

### DIFF
--- a/Essentials/Commands/EntityModule.cs
+++ b/Essentials/Commands/EntityModule.cs
@@ -305,8 +305,9 @@ namespace Essentials
                 {
                     controller.Use();
                     Context.Respond($"Player '{playerName}' ejected.");
-
-                } else {
+                } 
+                else 
+                {
                     Context.Respond("Player not seated.");
                 }
 

--- a/Essentials/Commands/EntityModule.cs
+++ b/Essentials/Commands/EntityModule.cs
@@ -18,9 +18,8 @@ using VRage.ModAPI;
 using VRage.Game;
 using VRage.Network;
 using VRage.Replication;
-using IMyDestroyableObject = VRage.Game.ModAPI.Interfaces.IMyDestroyableObject;
-
-
+using Sandbox.Game;
+using VRage.Game.ModAPI.Interfaces;
 
 namespace Essentials
 {
@@ -138,29 +137,42 @@ namespace Essentials
 
         [Command("kill", "kill a player.")]
         [Permission(MyPromoteLevel.SpaceMaster)]
-        public void Kill(string name)
+        public void Kill(string playerName)
         {
-            if (string.IsNullOrEmpty(name))
+            /* 
+             * First we try killing the player when hes online. This is easy and fast 
+             * and can also kill the player while being seated. 
+             */
+            var player = Utilities.GetPlayerByNameOrId(playerName);
+            if (player != null) 
             {
-                Context.Respond($"you must specify a user to kill, you idiot");
+                MyVisualScriptLogicProvider.SetPlayersHealth(player.IdentityId, 0);
+
+                Context.Torch.CurrentSession?.Managers?.GetManager<IChatManagerServer>()?.SendMessageAsSelf
+                    ($"{player.DisplayName} was killed by an admin");
+
                 return;
             }
 
-            if (!Utilities.TryGetEntityByNameOrId(name, out IMyEntity entity))
-            {
-                Context.Respond($"Entity '{name}' not found.");
+            /* 
+             * If we could not find the player there is a chance he is offline, in that case we try inflicting
+             * damage to the character as the VST will not help us with offline characters. 
+             */
+            if (!Utilities.TryGetEntityByNameOrId(playerName, out IMyEntity entity)) {
+                Context.Respond($"Entity '{playerName}' not found.");
                 return;
             }
 
-            if (entity is IMyCharacter)
+            if (entity is IMyCharacter) 
             {
                 var destroyable = entity as IMyDestroyableObject;
+
                 destroyable.DoDamage(1000f, MyDamageType.Radioactivity, true);
+
                 Context.Torch.CurrentSession?.Managers?.GetManager<IChatManagerServer>()?.SendMessageAsSelf
                     ($"{entity.DisplayName} was killed by an admin");
             }
         }
-
 
         [Command("find", "Find entities with the given text in their name.")]
         [Permission(MyPromoteLevel.SpaceMaster)]
@@ -251,51 +263,75 @@ namespace Essentials
         }
 
         [Command("eject", "Ejects a specific player from any block they are seated in, or all players in the server if run with 'all'")]
-        public void Eject(string player)
-        {
-            if (player.ToLower() == "all")
-            {
-                foreach (var ap in MySession.Static.Players.GetOnlinePlayers())
-                {
-                    var parent = ap.Character?.Parent;
-                    if (parent == null)
-                        continue;
+        public void Eject(string playerName) {
 
-                    if (parent is MyShipController c)
+            if (playerName.ToLower() == "all") 
+            {
+                EjectAllPlayers();
+            }
+            else 
+            {
+                EjectSinglePlayer(playerName);
+            }
+        }
+
+        private void EjectAllPlayers() {
+
+            int ejectedPlayersCount = 0;
+
+            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().ToList()) 
+            {
+                foreach (var controller in grid.GetFatBlocks<MyShipController>()) 
+                {
+                    if (controller.Pilot != null) 
                     {
-                        c.RemoveUsers(false);
-                        //Context.Respond($"Ejected {parent.DisplayName} from seat.");
-                        continue;
+                        controller.Use();
+                        ejectedPlayersCount++;
                     }
-                    throw new Exception($"Unknown block parent type! {parent.GetType().FullName}");
                 }
-
-                Context.Respond("Ejected all players from seats");
             }
-            else
+
+            Context.Respond($"Ejected '{ejectedPlayersCount}' players from their seats.");
+        }
+
+        private void EjectSinglePlayer(string playerName) {
+
+            /* We check first if the player is among the online players before looping over all grids for nothing. */
+            var player = Utilities.GetPlayerByNameOrId(playerName);
+            if (player != null) 
             {
-                var p = Utilities.GetPlayerByNameOrId(player);
-                if (p == null)
+                /* If he is online we check if he is currently seated. If he is eject him. */
+                if (player?.Controller.ControlledEntity is MyCockpit controller) 
                 {
-                    Context.Respond($"Could not find player {player}");
-                    return;
+                    controller.Use();
+                    Context.Respond($"Player '{playerName}' ejected.");
+
+                } else {
+                    Context.Respond("Player not seated.");
                 }
 
-                var parent = p.Character?.Parent;
-                if (parent == null)
-                {
-                    Context.Respond("Player is not seated.");
-                    return;
-                }
-
-                if (parent is MyShipController c)
-                {
-                    c.RemoveUsers(false);
-                    Context.Respond($"Ejected {p.DisplayName} from seat.");
-                    return;
-                }
-                throw new Exception($"Unknown block parent type! {parent.GetType().FullName}");
+                return;
             }
+
+            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().ToList()) 
+            {
+                foreach (var controller in grid.GetFatBlocks<MyShipController>()) 
+                {
+                    var pilot = controller.Pilot;
+
+                    if (pilot != null && pilot.DisplayName == playerName) 
+                    {
+                        controller.Use();
+
+                        Context.Respond($"Player '{playerName}' ejected.");
+
+                        /* We found our player. so no need to continue looking */
+                        return;
+                    }
+                }
+            }
+
+            Context.Respond("Offline player not found or seated.");
         }
     }
 }

--- a/Essentials/Commands/GridModule.cs
+++ b/Essentials/Commands/GridModule.cs
@@ -14,8 +14,9 @@ using VRage.Game.ModAPI;
 using VRage.ModAPI;
 using VRage.Game;
 using VRage.ObjectBuilders;
-
-
+using ALE_Core.Utils;
+using System.Collections.Concurrent;
+using VRage.Groups;
 
 namespace Essentials
 {
@@ -63,6 +64,72 @@ namespace Essentials
                 cubeBlock?.ChangeOwner(identityId, ownerComp.ShareMode);
                 return false;
             });*/
+        }
+
+        [Command("ejectall", "Ejects all Players from given grid.")]
+        [Permission(MyPromoteLevel.SpaceMaster)]
+        public void Eject(string gridName = null) 
+        {
+            ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> gridGroups;
+
+            if (gridName == null) 
+            {
+                if(Context.Player == null) 
+                {
+                    Context.Respond("The console always has to pass a gridname!");
+                    return;
+                }
+
+                IMyCharacter character = Context.Player.Character;
+
+                if (character == null) 
+                {
+                    Context.Respond("You need to spawn into a character when not using gridname!");
+                    return;
+                }
+
+                gridGroups = GridFinder.FindLookAtGridGroupMechanical(character);
+
+                if (gridGroups.Count == 0) 
+                {
+                    Context.Respond("You grid in your line of sight found! Remember not to use spectator!");
+                    return;
+                }
+            } 
+            else 
+            {
+                gridGroups = GridFinder.FindGridGroupMechanical(gridName);
+
+                if (gridGroups.Count == 0) 
+                {
+                    Context.Respond($"Grid with name '{gridName}' was not found!");
+                    return;
+                }
+
+                if (gridGroups.Count > 1) 
+                {
+                    Context.Respond($"There were multiple grids with name '{gridName}' to prevent any mistakes this command will not be executed!");
+                    return;
+                }
+            }
+
+            var group = gridGroups.First();
+
+            foreach(var node in group.Nodes) 
+            {
+
+                MyCubeGrid grid = node.NodeData;
+
+                foreach(var fatBlock in grid.GetFatBlocks()) 
+                {
+
+                    if (!(fatBlock is MyShipController shipController))
+                        continue;
+
+                    if (shipController.Pilot != null)
+                        shipController.Use();
+                }
+            }
         }
 
         [Command("static large", "Makes all large grids static.")]

--- a/Essentials/Commands/GridModule.cs
+++ b/Essentials/Commands/GridModule.cs
@@ -14,7 +14,6 @@ using VRage.Game.ModAPI;
 using VRage.ModAPI;
 using VRage.Game;
 using VRage.ObjectBuilders;
-using ALE_Core.Utils;
 using System.Collections.Concurrent;
 using VRage.Groups;
 
@@ -114,22 +113,26 @@ namespace Essentials
             }
 
             var group = gridGroups.First();
+            int ejectedPlayersCount = 0;
 
             foreach(var node in group.Nodes) 
             {
-
                 MyCubeGrid grid = node.NodeData;
 
                 foreach(var fatBlock in grid.GetFatBlocks()) 
                 {
-
                     if (!(fatBlock is MyShipController shipController))
                         continue;
 
-                    if (shipController.Pilot != null)
+                    if (shipController.Pilot != null) 
+                    {
                         shipController.Use();
+                        ejectedPlayersCount++;
+                    }
                 }
             }
+
+            Context.Respond($"Ejected '{ejectedPlayersCount}' players from their seats.");
         }
 
         [Command("static large", "Makes all large grids static.")]

--- a/Essentials/Commands/GridModule.cs
+++ b/Essentials/Commands/GridModule.cs
@@ -92,7 +92,7 @@ namespace Essentials
 
                 if (gridGroups.Count == 0) 
                 {
-                    Context.Respond("You grid in your line of sight found! Remember not to use spectator!");
+                    Context.Respond("No grid in your line of sight found! Remember to NOT use spectator!");
                     return;
                 }
             } 

--- a/Essentials/Commands/PlayerModule.cs
+++ b/Essentials/Commands/PlayerModule.cs
@@ -29,7 +29,12 @@ namespace Essentials
         [Permission(MyPromoteLevel.SpaceMaster)]
         public void Teleport(string entityToMove, string destination)
         {
-            Utilities.TryGetEntityByNameOrId(destination, out IMyEntity destEntity);
+
+            IMyEntity destEntity;
+            if (string.IsNullOrEmpty(destination))
+                destEntity = Context.Player?.Controller.ControlledEntity.Entity;
+            else
+                Utilities.TryGetEntityByNameOrId(destination, out destEntity);
 
             if (destEntity == null)
             {
@@ -62,6 +67,13 @@ namespace Essentials
         [Command("tpto", "Teleport directly to an another entity.")]
         [Permission(MyPromoteLevel.SpaceMaster)]
         public void TeleportTo(string destination, string entityToMove = null)
+        {
+            Teleport(entityToMove, destination);
+        }
+
+        [Command("tphere", "Teleport an other entity directly to you.")]
+        [Permission(MyPromoteLevel.SpaceMaster)]
+        public void TeleportHere(string entityToMove, string destination = null) 
         {
             Teleport(entityToMove, destination);
         }

--- a/Essentials/Commands/PlayerModule.cs
+++ b/Essentials/Commands/PlayerModule.cs
@@ -12,6 +12,7 @@ using VRage.Game;
 using VRage.Game.ModAPI;
 using VRage.ModAPI;
 using Torch.API.Managers;
+using Sandbox.Game;
 
 namespace Essentials
 {
@@ -100,6 +101,22 @@ namespace Essentials
             }
 
             Context.Torch.CurrentSession?.Managers?.GetManager<IChatManagerServer>()?.SendMessageAsOther(message, Context.Player?.DisplayName ?? "Server", MyFontEnum.Red, player.SteamUserId);
+        }
+
+        [Command("kill", "Kills a player.")]
+        [Permission(MyPromoteLevel.Moderator)]
+        public void Kill(string playerName) 
+        {
+            var player = Utilities.GetPlayerByNameOrId(playerName);
+            if (player != null)
+            {
+                MyVisualScriptLogicProvider.SetPlayersHealth(player.IdentityId, 0);
+                Context.Respond($"Player '{player.DisplayName}' killed.");
+            } 
+            else 
+            {
+                Context.Respond("Player not found.");
+            }
         }
 
         [Command("kick", "Kick a player from the game.")]

--- a/Essentials/Commands/PlayerModule.cs
+++ b/Essentials/Commands/PlayerModule.cs
@@ -71,7 +71,7 @@ namespace Essentials
             Teleport(entityToMove, destination);
         }
 
-        [Command("tphere", "Teleport an other entity directly to you.")]
+        [Command("tphere", "Teleport another entity directly to you.")]
         [Permission(MyPromoteLevel.SpaceMaster)]
         public void TeleportHere(string entityToMove, string destination = null) 
         {

--- a/Essentials/Commands/PlayerModule.cs
+++ b/Essentials/Commands/PlayerModule.cs
@@ -103,6 +103,29 @@ namespace Essentials
             Context.Torch.CurrentSession?.Managers?.GetManager<IChatManagerServer>()?.SendMessageAsOther(message, Context.Player?.DisplayName ?? "Server", MyFontEnum.Red, player.SteamUserId);
         }
 
+        [Command("eject", "Ejects a player from cockpit.")]
+        [Permission(MyPromoteLevel.Moderator)]
+        public void Eject(string playerName) 
+        {
+            var player = Utilities.GetPlayerByNameOrId(playerName);
+            if (player != null) 
+            {
+                if (player?.Controller.ControlledEntity is MyCockpit controller) 
+                {
+                    controller.Use();
+                    Context.Respond($"Player '{player.DisplayName}' ejected.");
+                } 
+                else 
+                {
+                    Context.Respond("Player cannot be ejected.");
+                }
+            } 
+            else 
+            {
+                Context.Respond("Player not found.");
+            }
+        }
+
         [Command("kill", "Kills a player.")]
         [Permission(MyPromoteLevel.Moderator)]
         public void Kill(string playerName) 

--- a/Essentials/Commands/PlayerModule.cs
+++ b/Essentials/Commands/PlayerModule.cs
@@ -12,7 +12,6 @@ using VRage.Game;
 using VRage.Game.ModAPI;
 using VRage.ModAPI;
 using Torch.API.Managers;
-using Sandbox.Game;
 
 namespace Essentials
 {
@@ -101,45 +100,6 @@ namespace Essentials
             }
 
             Context.Torch.CurrentSession?.Managers?.GetManager<IChatManagerServer>()?.SendMessageAsOther(message, Context.Player?.DisplayName ?? "Server", MyFontEnum.Red, player.SteamUserId);
-        }
-
-        [Command("eject", "Ejects a player from cockpit.")]
-        [Permission(MyPromoteLevel.Moderator)]
-        public void Eject(string playerName) 
-        {
-            var player = Utilities.GetPlayerByNameOrId(playerName);
-            if (player != null) 
-            {
-                if (player?.Controller.ControlledEntity is MyCockpit controller) 
-                {
-                    controller.Use();
-                    Context.Respond($"Player '{player.DisplayName}' ejected.");
-                } 
-                else 
-                {
-                    Context.Respond("Player cannot be ejected.");
-                }
-            } 
-            else 
-            {
-                Context.Respond("Player not found.");
-            }
-        }
-
-        [Command("kill", "Kills a player.")]
-        [Permission(MyPromoteLevel.Moderator)]
-        public void Kill(string playerName) 
-        {
-            var player = Utilities.GetPlayerByNameOrId(playerName);
-            if (player != null)
-            {
-                MyVisualScriptLogicProvider.SetPlayersHealth(player.IdentityId, 0);
-                Context.Respond($"Player '{player.DisplayName}' killed.");
-            } 
-            else 
-            {
-                Context.Respond("Player not found.");
-            }
         }
 
         [Command("kick", "Kick a player from the game.")]

--- a/Essentials/Essentials.csproj
+++ b/Essentials/Essentials.csproj
@@ -150,6 +150,7 @@
     <Compile Include="EssentialsPlugin.cs" />
     <Compile Include="Commands\GridModule.cs" />
     <Compile Include="Commands\PlayerModule.cs" />
+    <Compile Include="GridFinder.cs" />
     <Compile Include="InfoCommand.cs" />
     <Compile Include="Commands\InfoModule.cs" />
     <Compile Include="Patches\SessionDownloadPatch.cs" />

--- a/Essentials/GridFinder.cs
+++ b/Essentials/GridFinder.cs
@@ -1,0 +1,321 @@
+﻿using Sandbox.Game.Entities;
+using Sandbox.Game.Entities.Character;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using VRage.Game.ModAPI;
+using VRage.Groups;
+using VRageMath;
+
+namespace ALE_Core.Utils {
+
+    public class GridFinder {
+
+        public static ConcurrentBag<List<MyCubeGrid>> FindGridList(long playerId, bool includeConnectedGrids) {
+
+            ConcurrentBag<List<MyCubeGrid>> grids = new ConcurrentBag<List<MyCubeGrid>>();
+
+            if (includeConnectedGrids) {
+
+                Parallel.ForEach(MyCubeGridGroups.Static.Physical.Groups, group => {
+
+                    List<MyCubeGrid> gridList = new List<MyCubeGrid>();
+
+                    foreach (MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Node groupNodes in group.Nodes) {
+
+                        MyCubeGrid grid = groupNodes.NodeData;
+
+                        if (grid.Physics == null)
+                            continue;
+
+                        gridList.Add(grid);
+                    }
+
+                    if (IsPlayerIdCorrect(playerId, gridList))
+                        grids.Add(gridList);
+                });
+
+            } else {
+
+                Parallel.ForEach(MyCubeGridGroups.Static.Mechanical.Groups, group => {
+
+                    List<MyCubeGrid> gridList = new List<MyCubeGrid>();
+
+                    foreach (MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Node groupNodes in group.Nodes) {
+
+                        MyCubeGrid grid = groupNodes.NodeData;
+
+                        if (grid.Physics == null)
+                            continue;
+
+                        gridList.Add(grid);
+                    }
+
+                    if(IsPlayerIdCorrect(playerId, gridList))
+                        grids.Add(gridList);
+                });
+            }
+
+            return grids;
+        }
+
+        private static bool IsPlayerIdCorrect(long playerId, List<MyCubeGrid> gridList) {
+
+            MyCubeGrid biggestGrid = null;
+
+            foreach (var grid in gridList)
+                if (biggestGrid == null || biggestGrid.BlocksCount < grid.BlocksCount)
+                    biggestGrid = grid;
+
+            /* No biggest grid should not be possible, unless the gridgroup only had projections -.- just skip it. */
+            if (biggestGrid == null)
+                return false;
+
+            bool hasOwners = biggestGrid.BigOwners.Count != 0;
+
+            if(!hasOwners) {
+
+                if (playerId != 0L)
+                    return false;
+
+                return true;
+            }
+
+            return playerId == biggestGrid.BigOwners[0];
+        }
+
+        public static List<MyCubeGrid> FindGridList(string gridNameOrEntityId, MyCharacter character, bool includeConnectedGrids) {
+
+            List<MyCubeGrid> grids = new List<MyCubeGrid>();
+
+            if (gridNameOrEntityId == null && character == null)
+                return new List<MyCubeGrid>();
+
+            if (includeConnectedGrids) {
+
+                ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group> groups;
+
+                if (gridNameOrEntityId == null)
+                    groups = FindLookAtGridGroup(character);
+                else
+                    groups = FindGridGroup(gridNameOrEntityId);
+
+                if (groups.Count > 1)
+                    return null;
+
+                foreach (var group in groups) {
+                    foreach (var node in group.Nodes) {
+
+                        MyCubeGrid grid = node.NodeData;
+
+                        if (grid.Physics == null)
+                            continue;
+
+                        grids.Add(grid);
+                    }
+                }
+
+            } else {
+
+                ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> groups;
+
+                if (gridNameOrEntityId == null)
+                    groups = FindLookAtGridGroupMechanical(character);
+                else
+                    groups = FindGridGroupMechanical(gridNameOrEntityId);
+
+                if (groups.Count > 1)
+                    return null;
+
+                foreach (var group in groups) {
+                    foreach (var node in group.Nodes) {
+
+                        MyCubeGrid grid = node.NodeData;
+
+                        if (grid.Physics == null)
+                            continue;
+
+                        grids.Add(grid);
+                    }
+                }
+            }
+
+            return grids;
+        }
+
+        public static ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group> FindGridGroup(string gridName) {
+
+            ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group> groups = new ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group>();
+            Parallel.ForEach(MyCubeGridGroups.Static.Physical.Groups, group => {
+
+                foreach (MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Node groupNodes in group.Nodes) {
+
+                    MyCubeGrid grid = groupNodes.NodeData;
+
+                    if (grid.Physics == null)
+                        continue;
+
+                    /* Gridname is wrong ignore */
+                    if (!grid.DisplayName.Equals(gridName) && grid.EntityId+"" != gridName)
+                        continue;
+
+                    groups.Add(group);
+                }
+            });
+
+            return groups;
+        }
+
+        public static ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group> FindLookAtGridGroup(IMyCharacter controlledEntity) {
+
+            const float range = 5000;
+            Matrix worldMatrix;
+            Vector3D startPosition;
+            Vector3D endPosition;
+
+            worldMatrix = controlledEntity.GetHeadMatrix(true, true, false); // dead center of player cross hairs, or the direction the player is looking with ALT.
+            startPosition = worldMatrix.Translation + worldMatrix.Forward * 0.5f;
+            endPosition = worldMatrix.Translation + worldMatrix.Forward * (range + 0.5f);
+
+            var list = new Dictionary<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group, double>();
+            var ray = new RayD(startPosition, worldMatrix.Forward);
+
+            foreach (var group in MyCubeGridGroups.Static.Physical.Groups) {
+
+                foreach (MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Node groupNodes in group.Nodes) {
+
+                    IMyCubeGrid cubeGrid = groupNodes.NodeData;
+
+                    if (cubeGrid != null) {
+
+                        if (cubeGrid.Physics == null)
+                            continue;
+
+                        // check if the ray comes anywhere near the Grid before continuing.    
+                        if (ray.Intersects(cubeGrid.WorldAABB).HasValue) {
+
+                            Vector3I? hit = cubeGrid.RayCastBlocks(startPosition, endPosition);
+
+                            if (hit.HasValue) {
+
+                                double distance = (startPosition - cubeGrid.GridIntegerToWorld(hit.Value)).Length();
+
+
+                                if (list.TryGetValue(group, out double oldDistance)) {
+
+                                    if (distance < oldDistance) {
+                                        list.Remove(group);
+                                        list.Add(group, distance);
+                                    }
+
+                                } else {
+
+                                    list.Add(group, distance);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group> bag = new ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group>();
+
+            if (list.Count == 0)
+                return bag;
+
+            // find the closest Entity.
+            var item = list.OrderBy(f => f.Value).First();
+            bag.Add(item.Key);
+
+            return bag;
+        }
+
+        public static ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> FindGridGroupMechanical(string gridName) {
+
+            ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> groups = new ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group>();
+            Parallel.ForEach(MyCubeGridGroups.Static.Mechanical.Groups, group => {
+
+                foreach (MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Node groupNodes in group.Nodes) {
+
+                    MyCubeGrid grid = groupNodes.NodeData;
+
+                    if (grid.Physics == null)
+                        continue;
+
+                    /* Gridname is wrong ignore */
+                    if (!grid.DisplayName.Equals(gridName) && grid.EntityId + "" != gridName)
+                        continue;
+
+                    groups.Add(group);
+                }
+            });
+
+            return groups;
+        }
+
+        public static ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> FindLookAtGridGroupMechanical(IMyCharacter controlledEntity) {
+
+            const float range = 5000;
+            Matrix worldMatrix;
+            Vector3D startPosition;
+            Vector3D endPosition;
+
+            worldMatrix = controlledEntity.GetHeadMatrix(true, true, false); // dead center of player cross hairs, or the direction the player is looking with ALT.
+            startPosition = worldMatrix.Translation + worldMatrix.Forward * 0.5f;
+            endPosition = worldMatrix.Translation + worldMatrix.Forward * (range + 0.5f);
+
+            var list = new Dictionary<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group, double>();
+            var ray = new RayD(startPosition, worldMatrix.Forward);
+
+            foreach (var group in MyCubeGridGroups.Static.Mechanical.Groups) {
+
+                foreach (MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Node groupNodes in group.Nodes) {
+
+                    IMyCubeGrid cubeGrid = groupNodes.NodeData;
+
+                    if (cubeGrid != null) {
+
+                        if (cubeGrid.Physics == null)
+                            continue;
+
+                        // check if the ray comes anywhere near the Grid before continuing.    
+                        if (ray.Intersects(cubeGrid.WorldAABB).HasValue) {
+
+                            Vector3I? hit = cubeGrid.RayCastBlocks(startPosition, endPosition);
+
+                            if (hit.HasValue) {
+
+                                double distance = (startPosition - cubeGrid.GridIntegerToWorld(hit.Value)).Length();
+
+
+                                if (list.TryGetValue(group, out double oldDistance)) {
+
+                                    if (distance < oldDistance) {
+                                        list.Remove(group);
+                                        list.Add(group, distance);
+                                    }
+
+                                } else {
+
+                                    list.Add(group, distance);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> bag = new ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group>();
+
+            if (list.Count == 0)
+                return bag;
+
+            // find the closest Entity.
+            var item = list.OrderBy(f => f.Value).First();
+            bag.Add(item.Key);
+
+            return bag;
+        }
+    }
+}

--- a/Essentials/GridFinder.cs
+++ b/Essentials/GridFinder.cs
@@ -8,237 +8,19 @@ using VRage.Game.ModAPI;
 using VRage.Groups;
 using VRageMath;
 
-namespace ALE_Core.Utils {
-
-    public class GridFinder {
-
-        public static ConcurrentBag<List<MyCubeGrid>> FindGridList(long playerId, bool includeConnectedGrids) {
-
-            ConcurrentBag<List<MyCubeGrid>> grids = new ConcurrentBag<List<MyCubeGrid>>();
-
-            if (includeConnectedGrids) {
-
-                Parallel.ForEach(MyCubeGridGroups.Static.Physical.Groups, group => {
-
-                    List<MyCubeGrid> gridList = new List<MyCubeGrid>();
-
-                    foreach (MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Node groupNodes in group.Nodes) {
-
-                        MyCubeGrid grid = groupNodes.NodeData;
-
-                        if (grid.Physics == null)
-                            continue;
-
-                        gridList.Add(grid);
-                    }
-
-                    if (IsPlayerIdCorrect(playerId, gridList))
-                        grids.Add(gridList);
-                });
-
-            } else {
-
-                Parallel.ForEach(MyCubeGridGroups.Static.Mechanical.Groups, group => {
-
-                    List<MyCubeGrid> gridList = new List<MyCubeGrid>();
-
-                    foreach (MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Node groupNodes in group.Nodes) {
-
-                        MyCubeGrid grid = groupNodes.NodeData;
-
-                        if (grid.Physics == null)
-                            continue;
-
-                        gridList.Add(grid);
-                    }
-
-                    if(IsPlayerIdCorrect(playerId, gridList))
-                        grids.Add(gridList);
-                });
-            }
-
-            return grids;
-        }
-
-        private static bool IsPlayerIdCorrect(long playerId, List<MyCubeGrid> gridList) {
-
-            MyCubeGrid biggestGrid = null;
-
-            foreach (var grid in gridList)
-                if (biggestGrid == null || biggestGrid.BlocksCount < grid.BlocksCount)
-                    biggestGrid = grid;
-
-            /* No biggest grid should not be possible, unless the gridgroup only had projections -.- just skip it. */
-            if (biggestGrid == null)
-                return false;
-
-            bool hasOwners = biggestGrid.BigOwners.Count != 0;
-
-            if(!hasOwners) {
-
-                if (playerId != 0L)
-                    return false;
-
-                return true;
-            }
-
-            return playerId == biggestGrid.BigOwners[0];
-        }
-
-        public static List<MyCubeGrid> FindGridList(string gridNameOrEntityId, MyCharacter character, bool includeConnectedGrids) {
-
-            List<MyCubeGrid> grids = new List<MyCubeGrid>();
-
-            if (gridNameOrEntityId == null && character == null)
-                return new List<MyCubeGrid>();
-
-            if (includeConnectedGrids) {
-
-                ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group> groups;
-
-                if (gridNameOrEntityId == null)
-                    groups = FindLookAtGridGroup(character);
-                else
-                    groups = FindGridGroup(gridNameOrEntityId);
-
-                if (groups.Count > 1)
-                    return null;
-
-                foreach (var group in groups) {
-                    foreach (var node in group.Nodes) {
-
-                        MyCubeGrid grid = node.NodeData;
-
-                        if (grid.Physics == null)
-                            continue;
-
-                        grids.Add(grid);
-                    }
-                }
-
-            } else {
-
-                ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> groups;
-
-                if (gridNameOrEntityId == null)
-                    groups = FindLookAtGridGroupMechanical(character);
-                else
-                    groups = FindGridGroupMechanical(gridNameOrEntityId);
-
-                if (groups.Count > 1)
-                    return null;
-
-                foreach (var group in groups) {
-                    foreach (var node in group.Nodes) {
-
-                        MyCubeGrid grid = node.NodeData;
-
-                        if (grid.Physics == null)
-                            continue;
-
-                        grids.Add(grid);
-                    }
-                }
-            }
-
-            return grids;
-        }
-
-        public static ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group> FindGridGroup(string gridName) {
-
-            ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group> groups = new ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group>();
-            Parallel.ForEach(MyCubeGridGroups.Static.Physical.Groups, group => {
-
-                foreach (MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Node groupNodes in group.Nodes) {
-
-                    MyCubeGrid grid = groupNodes.NodeData;
-
-                    if (grid.Physics == null)
-                        continue;
-
-                    /* Gridname is wrong ignore */
-                    if (!grid.DisplayName.Equals(gridName) && grid.EntityId+"" != gridName)
-                        continue;
-
-                    groups.Add(group);
-                }
-            });
-
-            return groups;
-        }
-
-        public static ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group> FindLookAtGridGroup(IMyCharacter controlledEntity) {
-
-            const float range = 5000;
-            Matrix worldMatrix;
-            Vector3D startPosition;
-            Vector3D endPosition;
-
-            worldMatrix = controlledEntity.GetHeadMatrix(true, true, false); // dead center of player cross hairs, or the direction the player is looking with ALT.
-            startPosition = worldMatrix.Translation + worldMatrix.Forward * 0.5f;
-            endPosition = worldMatrix.Translation + worldMatrix.Forward * (range + 0.5f);
-
-            var list = new Dictionary<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group, double>();
-            var ray = new RayD(startPosition, worldMatrix.Forward);
-
-            foreach (var group in MyCubeGridGroups.Static.Physical.Groups) {
-
-                foreach (MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Node groupNodes in group.Nodes) {
-
-                    IMyCubeGrid cubeGrid = groupNodes.NodeData;
-
-                    if (cubeGrid != null) {
-
-                        if (cubeGrid.Physics == null)
-                            continue;
-
-                        // check if the ray comes anywhere near the Grid before continuing.    
-                        if (ray.Intersects(cubeGrid.WorldAABB).HasValue) {
-
-                            Vector3I? hit = cubeGrid.RayCastBlocks(startPosition, endPosition);
-
-                            if (hit.HasValue) {
-
-                                double distance = (startPosition - cubeGrid.GridIntegerToWorld(hit.Value)).Length();
-
-
-                                if (list.TryGetValue(group, out double oldDistance)) {
-
-                                    if (distance < oldDistance) {
-                                        list.Remove(group);
-                                        list.Add(group, distance);
-                                    }
-
-                                } else {
-
-                                    list.Add(group, distance);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group> bag = new ConcurrentBag<MyGroups<MyCubeGrid, MyGridPhysicalGroupData>.Group>();
-
-            if (list.Count == 0)
-                return bag;
-
-            // find the closest Entity.
-            var item = list.OrderBy(f => f.Value).First();
-            bag.Add(item.Key);
-
-            return bag;
-        }
-
-        public static ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> FindGridGroupMechanical(string gridName) {
-
-            ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> groups = new ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group>();
-            Parallel.ForEach(MyCubeGridGroups.Static.Mechanical.Groups, group => {
-
-                foreach (MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Node groupNodes in group.Nodes) {
-
-                    MyCubeGrid grid = groupNodes.NodeData;
+namespace Essentials
+{
+    public class GridFinder 
+    {
+        public static ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> FindGridGroupMechanical(string gridName) 
+        {
+            var groups = new ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group>();
+
+            Parallel.ForEach(MyCubeGridGroups.Static.Mechanical.Groups, group => 
+            {
+                foreach (MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Node groupNodes in group.Nodes) 
+                {
+                    var grid = groupNodes.NodeData;
 
                     if (grid.Physics == null)
                         continue;
@@ -254,8 +36,8 @@ namespace ALE_Core.Utils {
             return groups;
         }
 
-        public static ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> FindLookAtGridGroupMechanical(IMyCharacter controlledEntity) {
-
+        public static ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> FindLookAtGridGroupMechanical(IMyCharacter controlledEntity) 
+        {
             const float range = 5000;
             Matrix worldMatrix;
             Vector3D startPosition;
@@ -268,45 +50,42 @@ namespace ALE_Core.Utils {
             var list = new Dictionary<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group, double>();
             var ray = new RayD(startPosition, worldMatrix.Forward);
 
-            foreach (var group in MyCubeGridGroups.Static.Mechanical.Groups) {
-
-                foreach (MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Node groupNodes in group.Nodes) {
-
+            foreach (var group in MyCubeGridGroups.Static.Mechanical.Groups) 
+            {
+                foreach (MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Node groupNodes in group.Nodes) 
+                {
                     IMyCubeGrid cubeGrid = groupNodes.NodeData;
 
-                    if (cubeGrid != null) {
+                    if (cubeGrid == null || cubeGrid.Physics == null)
+                        continue;
 
-                        if (cubeGrid.Physics == null)
-                            continue;
+                    // check if the ray comes anywhere near the Grid before continuing.    
+                    if (!ray.Intersects(cubeGrid.WorldAABB).HasValue)
+                        continue;
 
-                        // check if the ray comes anywhere near the Grid before continuing.    
-                        if (ray.Intersects(cubeGrid.WorldAABB).HasValue) {
+                    Vector3I? hit = cubeGrid.RayCastBlocks(startPosition, endPosition);
 
-                            Vector3I? hit = cubeGrid.RayCastBlocks(startPosition, endPosition);
+                    if (!hit.HasValue)
+                        continue;
 
-                            if (hit.HasValue) {
+                    double distance = (startPosition - cubeGrid.GridIntegerToWorld(hit.Value)).Length();
 
-                                double distance = (startPosition - cubeGrid.GridIntegerToWorld(hit.Value)).Length();
-
-
-                                if (list.TryGetValue(group, out double oldDistance)) {
-
-                                    if (distance < oldDistance) {
-                                        list.Remove(group);
-                                        list.Add(group, distance);
-                                    }
-
-                                } else {
-
-                                    list.Add(group, distance);
-                                }
-                            }
+                    if (list.TryGetValue(group, out double oldDistance)) 
+                    {
+                        if (distance < oldDistance) 
+                        {
+                            list.Remove(group);
+                            list.Add(group, distance);
                         }
+                    } 
+                    else 
+                    {
+                        list.Add(group, distance);
                     }
                 }
             }
 
-            ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> bag = new ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group>();
+            var bag = new ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group>();
 
             if (list.Count == 0)
                 return bag;


### PR DESCRIPTION
Since we already had a tpto command I thought it may be useful to also have tphere command. 

A thing I want to try to change however is dealing with players that are seated in the cockpit. Which currently I have not done. Its nice to be able to tp grids or to grids, but if you want to tp to a player inside a grid its still broken :-(

There also now is a command to eject a given player from any seat. Since we had instances on our server where a player was stuck he had to disconnect so we could delete his character from the game and then he could reconnect. An eject command shall improve that. However as everything with essentials it wont work with offline players.

Same goes for the new kill command.

Since you cannot eject offline players we also now have a grids ejectall command where you can either call it by passing a gridname or like my ALE plugins by looking at them. 

The GridFinder is a copy from my ALE Core 