### PR TITLE
Command to delete grids that fail an IsWorking check for a specified block.

### DIFF
--- a/Essentials/AutoCommand.cs
+++ b/Essentials/AutoCommand.cs
@@ -25,27 +25,25 @@ namespace Essentials
         private DateTime _nextRun = DateTime.MinValue;
         private DayOfWeek _day = DayOfWeek.All;
         private Trigger _trigger = Trigger.Disabled;
-        private Gtl _comparer = Gtl.LessThan;
         private int _currentStep;
         private string _name;
         private float _triggerRatio;
         private double _triggerCount;
 
-
+        /*
+        [Display(Description = "Enables or disables this command. NOTE: !admin runauto does NOT respect this setting!")]
+        public bool Enabled
+        {
+            get => _enabled;
+            set => SetValue(ref _enabled, value);
+        }
+        */
         [Display(Name = "Trigger", Description ="Choose a trigger for the command")]
         public Trigger CommandTrigger
         {
             get => _trigger;
             set => SetValue(ref _trigger, value);
         }
-        
-        [Display(Name = "Trigger Operator", Description ="Choose a Ratio Comparer for the command")]
-        public Gtl Compare
-        {
-            get => _comparer;
-            set => SetValue(ref _comparer, value);
-        }
-
         
         [Display(Description = "Sets the name of this command. Use this name in conjunction with !admin runauto to trigger the command from ingame or from other auto commands.")]
         public string Name
@@ -122,19 +120,13 @@ namespace Essentials
             if (DateTime.Now < _nextRun)
                 return;
 
-            switch (CommandTrigger)
-            {
-                case Trigger.GridCount:
-                case Trigger.SimSpeed:
-                case Trigger.PlayerCount:
-                    RunNow();
-                    _nextRun = DateTime.Now + _interval;
-                    return;
-                case Trigger.Scheduled when Interval == TimeSpan.Zero.ToString() && DayOfWeek != DayOfWeek.All && DateTime.Now.DayOfWeek != (System.DayOfWeek)(int)DayOfWeek:
+            if(CommandTrigger == Trigger.Scheduled && Interval == TimeSpan.Zero.ToString())
+                if (DayOfWeek != DayOfWeek.All && DateTime.Now.DayOfWeek != (System.DayOfWeek)(int)DayOfWeek)
+                {
                     //adding one day because I can't be bothered to calculate exact interval
                     _nextRun += TimeSpan.FromDays(1);
                     return;
-            }
+                }
 
 
             if (Steps.Count <= 0)
@@ -148,9 +140,11 @@ namespace Essentials
 
             if (_currentStep < Steps.Count) return;
             _currentStep = 0;
-            _nextRun = _scheduledTime != TimeSpan.Zero
-                    ? DateTime.Now.Date + _scheduledTime + TimeSpan.FromDays(1)
-                    : _nextRun = DateTime.Now + _interval;
+            if(CommandTrigger == Trigger.Scheduled && Interval == TimeSpan.Zero.ToString())
+                _nextRun = DateTime.Now.Date + _scheduledTime + TimeSpan.FromDays(1);
+            else if((CommandTrigger != Trigger.Disabled || CommandTrigger != Trigger.Vote) && Interval != TimeSpan.Zero.ToString())
+
+                _nextRun = DateTime.Now + _interval;
         }
 
 
@@ -215,13 +209,6 @@ namespace Essentials
         {
             return $"{Name} : {_trigger.ToString()} : {Steps.Count}";
         }
-    }
-    
-    public enum Gtl
-    {
-        LessThan,
-        GreaterThan,
-        Equal
     }
 
     public enum Trigger

--- a/Essentials/AutoCommands.cs
+++ b/Essentials/AutoCommands.cs
@@ -43,8 +43,11 @@ namespace Essentials
                 case Trigger.Disabled:
                     return  false;
                 case Trigger.OnStart:
-                    return Math.Abs((MyAPIGateway.Session.ElapsedPlayTime - TimeSpan.Parse(command.Interval))
-                               .TotalSeconds) < 1;
+		                    var a = Math.Max(TimeSpan.Parse(command.Interval).TotalSeconds, 60);
+		                    var b = ((ITorchServer)TorchBase.Instance).ElapsedPlayTime;
+		                    if  ((a - b.TotalSeconds) <= 1 && (a - b.TotalSeconds > 0))
+		                        command.RunNow();
+                    break;
                 case Trigger.Vote:
                     break;
                 case Trigger.Timed:

--- a/Essentials/AutoCommands.cs
+++ b/Essentials/AutoCommands.cs
@@ -10,7 +10,9 @@ using Torch.Server.ViewModels;
 using Sandbox.Game.World;
 using Sandbox.Game.Multiplayer;
 using Sandbox.Game.Entities;
+using Sandbox.ModAPI;
 using VRage.Game.ModAPI;
+using static Essentials.Gtl;
 
 
 namespace Essentials
@@ -23,6 +25,8 @@ namespace Essentials
         public static AutoCommands Instance => _instance ?? (_instance = new AutoCommands());
         private static readonly Logger Log = LogManager.GetLogger("Essentials");
         private Timer _timer;
+        private readonly Dictionary<AutoCommand,DateTime> _simSpeedCheck  = new Dictionary<AutoCommand, DateTime>();
+
 
         public void Start()
         {
@@ -39,11 +43,8 @@ namespace Essentials
                 case Trigger.Disabled:
                     return  false;
                 case Trigger.OnStart:
-                    var a = Math.Max(TimeSpan.Parse(command.Interval).TotalSeconds, 60);
-                    var b = ((ITorchServer)TorchBase.Instance).ElapsedPlayTime;
-                    if  ((a - b.TotalSeconds) <= 1 && (a - b.TotalSeconds > 0))
-                        command.RunNow();
-                    break;
+                    return Math.Abs((MyAPIGateway.Session.ElapsedPlayTime - TimeSpan.Parse(command.Interval))
+                               .TotalSeconds) < 1;
                 case Trigger.Vote:
                     break;
                 case Trigger.Timed:
@@ -51,12 +52,72 @@ namespace Essentials
                 case Trigger.Scheduled:
                     return true;
                 case Trigger.GridCount:
-                        return Tree.Grids.Count >= command.TriggerCount;
+                    var gridCount = MyEntities.GetEntities().OfType<IMyCubeGrid>().Count();
+                    switch (command.Compare)
+                    {
+                        case GreaterThan:
+                            return gridCount > command.TriggerCount;
+                        case LessThan:
+                            return gridCount < command.TriggerCount;
+                        case Equal:
+                            return Math.Abs(gridCount-command.TriggerCount)<1;
+                        default:
+                            throw new Exception("meh");
+                    }
                 case Trigger.PlayerCount:
-                    return MySession.Static.Players.GetOnlinePlayerCount() >= command.TriggerCount;
-                case Trigger.SimSpeed:
-                    return Math.Min(Sync.ServerSimulationRatio, 1) <= command.TriggerRatio;
+                    switch (command.Compare)
+                    {
+                        case GreaterThan:
+                            return MySession.Static.Players.GetOnlinePlayerCount() >= command.TriggerCount;
+                        case LessThan:
+                            return MySession.Static.Players.GetOnlinePlayerCount() <= command.TriggerCount;
+                        default:
+                            throw new Exception("meh");
+                    }
 
+                case Trigger.SimSpeed:
+                    var commandActive = _simSpeedCheck.TryGetValue(command, out var time);
+                    switch (command.Compare)
+                    {
+                        case GreaterThan:
+                            if (commandActive)
+                            {
+                                if ((DateTime.Now - time).TotalSeconds < command.TriggerCount) break;
+                                _simSpeedCheck.Remove(command);
+                                return Math.Min(Sync.ServerSimulationRatio, 1) > command.TriggerRatio;
+                            }
+
+                            if (Math.Min(Sync.ServerSimulationRatio, 1) < command.TriggerRatio) break;
+                            _simSpeedCheck.Add(command, DateTime.Now);
+                            break;
+
+                        case LessThan:
+                            if (commandActive)
+                            {
+                                if ((DateTime.Now - time).TotalSeconds < command.TriggerCount) break;
+                                _simSpeedCheck.Remove(command);
+                                return Math.Min(Sync.ServerSimulationRatio, 1) < command.TriggerRatio;
+                            }
+
+                            if (Math.Min(Sync.ServerSimulationRatio, 1) > command.TriggerRatio) break;
+                            _simSpeedCheck.Add(command, DateTime.Now);
+                            break;
+
+                        case Equal:
+                            if (commandActive)
+                            {
+                                if ((DateTime.Now - time).TotalSeconds < command.TriggerCount) break;
+                                _simSpeedCheck.Remove(command);
+                                return (Math.Abs(Sync.ServerSimulationRatio - command.TriggerRatio) <= 0);
+                            }
+
+                            if (Math.Abs(Sync.ServerSimulationRatio - command.TriggerRatio)>0)
+                                break;
+                            _simSpeedCheck.Add(command, DateTime.Now);
+                            break;
+                       }
+                       break;
+                            
                 default:
                     throw new Exception("fuck it");
             }

--- a/Essentials/AutoCommands.cs
+++ b/Essentials/AutoCommands.cs
@@ -39,8 +39,11 @@ namespace Essentials
                 case Trigger.Disabled:
                     return  false;
                 case Trigger.OnStart:
-                    return Math.Abs((MyAPIGateway.Session.ElapsedPlayTime - TimeSpan.Parse(command.Interval))
-                               .TotalSeconds) < 1;
+                    var a = Math.Max(TimeSpan.Parse(command.Interval).TotalSeconds, 60);
+                    var b = ((ITorchServer)TorchBase.Instance).ElapsedPlayTime;
+                    if  ((a - b.TotalSeconds) <= 1 && (a - b.TotalSeconds > 0))
+                        command.RunNow();
+                    break;
                 case Trigger.Vote:
                     break;
                 case Trigger.Timed:
@@ -48,72 +51,12 @@ namespace Essentials
                 case Trigger.Scheduled:
                     return true;
                 case Trigger.GridCount:
-                    var gridCount = MyEntities.GetEntities().OfType<IMyCubeGrid>().Count();
-                    switch (command.Compare)
-                    {
-                        case GreaterThan:
-                            return gridCount > command.TriggerCount;
-                        case LessThan:
-                            return gridCount < command.TriggerCount;
-                        case Equal:
-                            return Math.Abs(gridCount-command.TriggerCount)<1;
-                        default:
-                            throw new Exception("meh");
-                    }
+                        return Tree.Grids.Count >= command.TriggerCount;
                 case Trigger.PlayerCount:
-                    switch (command.Compare)
-                    {
-                        case GreaterThan:
-                            return MySession.Static.Players.GetOnlinePlayerCount() >= command.TriggerCount;
-                        case LessThan:
-                            return MySession.Static.Players.GetOnlinePlayerCount() <= command.TriggerCount;
-                        default:
-                            throw new Exception("meh");
-                    }
-
+                    return MySession.Static.Players.GetOnlinePlayerCount() >= command.TriggerCount;
                 case Trigger.SimSpeed:
-                    var commandActive = _simSpeedCheck.TryGetValue(command, out var time);
-                    switch (command.Compare)
-                    {
-                        case GreaterThan:
-                            if (commandActive)
-                            {
-                                if ((DateTime.Now - time).TotalSeconds < command.TriggerCount) break;
-                                _simSpeedCheck.Remove(command);
-                                return Math.Min(Sync.ServerSimulationRatio, 1) > command.TriggerRatio;
-                            }
+                    return Math.Min(Sync.ServerSimulationRatio, 1) <= command.TriggerRatio;
 
-                            if (Math.Min(Sync.ServerSimulationRatio, 1) < command.TriggerRatio) break;
-                            _simSpeedCheck.Add(command, DateTime.Now);
-                            break;
-
-                        case LessThan:
-                            if (commandActive)
-                            {
-                                if ((DateTime.Now - time).TotalSeconds < command.TriggerCount) break;
-                                _simSpeedCheck.Remove(command);
-                                return Math.Min(Sync.ServerSimulationRatio, 1) < command.TriggerRatio;
-                            }
-
-                            if (Math.Min(Sync.ServerSimulationRatio, 1) > command.TriggerRatio) break;
-                            _simSpeedCheck.Add(command, DateTime.Now);
-                            break;
-
-                        case Equal:
-                            if (commandActive)
-                            {
-                                if ((DateTime.Now - time).TotalSeconds < command.TriggerCount) break;
-                                _simSpeedCheck.Remove(command);
-                                return (Math.Abs(Sync.ServerSimulationRatio - command.TriggerRatio) <= 0);
-                            }
-
-                            if (Math.Abs(Sync.ServerSimulationRatio - command.TriggerRatio)>0)
-                                break;
-                            _simSpeedCheck.Add(command, DateTime.Now);
-                            break;
-                       }
-                       break;
-                            
                 default:
                     throw new Exception("fuck it");
             }

--- a/Essentials/AutoCommands.cs
+++ b/Essentials/AutoCommands.cs
@@ -39,11 +39,8 @@ namespace Essentials
                 case Trigger.Disabled:
                     return  false;
                 case Trigger.OnStart:
-                    var a = Math.Max(TimeSpan.Parse(command.Interval).TotalSeconds, 60);
-                    var b = ((ITorchServer)TorchBase.Instance).ElapsedPlayTime;
-                    if  ((a - b.TotalSeconds) <= 1 && (a - b.TotalSeconds > 0))
-                        command.RunNow();
-                    break;
+                    return Math.Abs((MyAPIGateway.Session.ElapsedPlayTime - TimeSpan.Parse(command.Interval))
+                               .TotalSeconds) < 1;
                 case Trigger.Vote:
                     break;
                 case Trigger.Timed:
@@ -51,12 +48,72 @@ namespace Essentials
                 case Trigger.Scheduled:
                     return true;
                 case Trigger.GridCount:
-                        return Tree.Grids.Count >= command.TriggerCount;
+                    var gridCount = MyEntities.GetEntities().OfType<IMyCubeGrid>().Count();
+                    switch (command.Compare)
+                    {
+                        case GreaterThan:
+                            return gridCount > command.TriggerCount;
+                        case LessThan:
+                            return gridCount < command.TriggerCount;
+                        case Equal:
+                            return Math.Abs(gridCount-command.TriggerCount)<1;
+                        default:
+                            throw new Exception("meh");
+                    }
                 case Trigger.PlayerCount:
-                    return MySession.Static.Players.GetOnlinePlayerCount() >= command.TriggerCount;
-                case Trigger.SimSpeed:
-                    return Math.Min(Sync.ServerSimulationRatio, 1) <= command.TriggerRatio;
+                    switch (command.Compare)
+                    {
+                        case GreaterThan:
+                            return MySession.Static.Players.GetOnlinePlayerCount() >= command.TriggerCount;
+                        case LessThan:
+                            return MySession.Static.Players.GetOnlinePlayerCount() <= command.TriggerCount;
+                        default:
+                            throw new Exception("meh");
+                    }
 
+                case Trigger.SimSpeed:
+                    var commandActive = _simSpeedCheck.TryGetValue(command, out var time);
+                    switch (command.Compare)
+                    {
+                        case GreaterThan:
+                            if (commandActive)
+                            {
+                                if ((DateTime.Now - time).TotalSeconds < command.TriggerCount) break;
+                                _simSpeedCheck.Remove(command);
+                                return Math.Min(Sync.ServerSimulationRatio, 1) > command.TriggerRatio;
+                            }
+
+                            if (Math.Min(Sync.ServerSimulationRatio, 1) < command.TriggerRatio) break;
+                            _simSpeedCheck.Add(command, DateTime.Now);
+                            break;
+
+                        case LessThan:
+                            if (commandActive)
+                            {
+                                if ((DateTime.Now - time).TotalSeconds < command.TriggerCount) break;
+                                _simSpeedCheck.Remove(command);
+                                return Math.Min(Sync.ServerSimulationRatio, 1) < command.TriggerRatio;
+                            }
+
+                            if (Math.Min(Sync.ServerSimulationRatio, 1) > command.TriggerRatio) break;
+                            _simSpeedCheck.Add(command, DateTime.Now);
+                            break;
+
+                        case Equal:
+                            if (commandActive)
+                            {
+                                if ((DateTime.Now - time).TotalSeconds < command.TriggerCount) break;
+                                _simSpeedCheck.Remove(command);
+                                return (Math.Abs(Sync.ServerSimulationRatio - command.TriggerRatio) <= 0);
+                            }
+
+                            if (Math.Abs(Sync.ServerSimulationRatio - command.TriggerRatio)>0)
+                                break;
+                            _simSpeedCheck.Add(command, DateTime.Now);
+                            break;
+                       }
+                       break;
+                            
                 default:
                     throw new Exception("fuck it");
             }

--- a/Essentials/Commands/AdminModule.cs
+++ b/Essentials/Commands/AdminModule.cs
@@ -298,5 +298,31 @@ namespace Essentials.Commands
             var ms = new DialogMessage("Muted Users", content: sb.ToString());
             ModCommunication.SendMessageTo(ms, Context.Player.SteamUserId);
         }
+
+        [Command("give", "Insert an item with a specific quanity into a players inventory")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void give(string playerName, string type, string item, int quantity) {
+            type = "MyObjectBuilder_" + type;
+            VRage.Game.MyDefinitionId.TryParse(type, item, out VRage.Game.MyDefinitionId defID);
+            if (defID.ToString().Contains("null")) {
+                Context.Respond("Invalid item type");
+                return;
+            }
+            if (playerName != "*") {
+                var p = Utilities.GetPlayerByNameOrId(playerName);
+                if (p == null) {
+                    Context.Respond("Player not found");
+                    return;
+                }
+                Sandbox.Game.MyVisualScriptLogicProvider.AddToPlayersInventory(p.IdentityId, defID, quantity);
+            }
+
+            else {
+                foreach (var p in MySession.Static.Players.GetOnlinePlayers()) {
+                    Sandbox.Game.MyVisualScriptLogicProvider.AddToPlayersInventory(p.Identity.IdentityId, defID, quantity);
+                }
+            }
+            Context.Respond("Item(s) given!");
+        }
     }
 }

--- a/Essentials/Commands/AdminModule.cs
+++ b/Essentials/Commands/AdminModule.cs
@@ -301,13 +301,15 @@ namespace Essentials.Commands
 
         [Command("give", "Insert an item with a specific quanity into a players inventory")]
         [Permission(MyPromoteLevel.Admin)]
-        public void give(string playerName, string type, string item, int quantity) {
-            type = "MyObjectBuilder_" + type;
+        public void give(string playerName, string itemType, string item, int quantity) {
+            string type = "MyObjectBuilder_" + itemType;
             VRage.Game.MyDefinitionId.TryParse(type, item, out VRage.Game.MyDefinitionId defID);
+
             if (defID.ToString().Contains("null")) {
                 Context.Respond("Invalid item type");
                 return;
             }
+
             if (playerName != "*") {
                 var p = Utilities.GetPlayerByNameOrId(playerName);
                 if (p == null) {
@@ -315,11 +317,14 @@ namespace Essentials.Commands
                     return;
                 }
                 Sandbox.Game.MyVisualScriptLogicProvider.AddToPlayersInventory(p.IdentityId, defID, quantity);
+                ModCommunication.SendMessageTo(new NotificationMessage($"You have been given {quantity} {item} {itemType}", 5000, "Blue"), p.SteamUserId);
             }
 
             else {
                 foreach (var p in MySession.Static.Players.GetOnlinePlayers()) {
+                    var player = Utilities.GetPlayerByNameOrId(p.DisplayName);
                     Sandbox.Game.MyVisualScriptLogicProvider.AddToPlayersInventory(p.Identity.IdentityId, defID, quantity);
+                    ModCommunication.SendMessageTo(new NotificationMessage($"You have been given {quantity} {item} {itemType}", 5000, "Blue"), player.SteamUserId);
                 }
             }
             Context.Respond("Item(s) given!");

--- a/Essentials/Commands/BlocksModule.cs
+++ b/Essentials/Commands/BlocksModule.cs
@@ -18,7 +18,7 @@ namespace Essentials.Commands
         public void OnType(string type)
         {
             var count = 0;
-            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>())
+            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(x => x.Projector == null))
             {
                 foreach (var block in grid.GetFatBlocks().OfType<MyFunctionalBlock>())
                 {
@@ -39,7 +39,7 @@ namespace Essentials.Commands
         public void OnSubtype(string subtype)
         {
             var count = 0;
-            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>())
+            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(x => x.Projector == null))
             {
                 foreach (var block in grid.GetFatBlocks().OfType<MyFunctionalBlock>())
                 {
@@ -60,7 +60,7 @@ namespace Essentials.Commands
         public void OffType(string type)
         {
             var count = 0;
-            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>())
+            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(x => x.Projector == null))
             {
                 foreach (var block in grid.GetFatBlocks().OfType<MyFunctionalBlock>())
                 {
@@ -82,7 +82,7 @@ namespace Essentials.Commands
         public void RemoveSubtype(string subtype)
         {
             var toRemove = new List<MySlimBlock>();
-            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>())
+            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(x => x.Projector == null))
             {
                 foreach (var block in grid.GetBlocks())
                 {
@@ -101,7 +101,7 @@ namespace Essentials.Commands
         public void RemoveType(string type)
         {
             var toRemove = new List<MySlimBlock>();
-            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>())
+            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(x => x.Projector == null))
             {
                 foreach (var block in grid.GetBlocks())
                 {
@@ -120,7 +120,7 @@ namespace Essentials.Commands
         public void OffSubtype(string subtype)
         {
             var count = 0;
-            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>())
+            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(x => x.Projector == null))
             {
                 foreach (var block in grid.GetFatBlocks().OfType<MyFunctionalBlock>())
                 {
@@ -144,7 +144,7 @@ namespace Essentials.Commands
             var count = 0;
             if (Enum.TryParse(category, out BlockCategory result))
             {
-                foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>())
+                foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(x => x.Projector == null))
                 {
                     foreach (var item in grid.GetFatBlocks().OfType<MyFunctionalBlock>())
                     {
@@ -178,7 +178,7 @@ namespace Essentials.Commands
 
             if (Enum.TryParse(category, out BlockCategory result))
             {
-                foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>())
+                foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(x => x.Projector == null))
                 {
                     foreach (var item in grid.GetFatBlocks().OfType<MyFunctionalBlock>())
                     {

--- a/Essentials/Commands/BlocksModule.cs
+++ b/Essentials/Commands/BlocksModule.cs
@@ -65,8 +65,7 @@ namespace Essentials.Commands
                 foreach (var block in grid.GetFatBlocks().OfType<MyFunctionalBlock>())
                 {
                     var blockType = block.BlockDefinition.Id.TypeId.ToString().Substring(16);
-                    if (block != null && string.Compare(type, blockType, StringComparison.InvariantCultureIgnoreCase) ==
-                        0)
+                    if (block != null && string.Compare(type, blockType, StringComparison.InvariantCultureIgnoreCase) == 0 && block.Enabled == true)
                     {
                         block.Enabled = false;
                         count++;

--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -295,6 +295,13 @@ namespace Essentials.Commands
                 return grid.BigOwners.Count == 0;
             }
 
+            if (string.Compare(str, "npc", StringComparison.Ordinal) == 0)
+            {
+                return grid.BigOwners.Count > 0 &&
+                       MySession.Static.Factions.IsNpcFaction(grid.BigOwners.FirstOrDefault());
+            }
+            
+
             if (string.Compare(str, "pirates", StringComparison.InvariantCultureIgnoreCase) == 0)
             {
                 identityId = MyPirateAntennas.GetPiratesId();
@@ -318,6 +325,7 @@ namespace Essentials.Commands
 
             return grid.BigOwners.Contains(identityId);
         }
+        
 
         [Condition("hastype", "notype", "Finds grids containing blocks of the given type.")]
         public bool BlockType(MyCubeGrid grid, string str)
@@ -334,7 +342,7 @@ namespace Essentials.Commands
         [Condition("haspilot", "Finds grids with pilots")]
         public bool Piloted(MyCubeGrid grid)
         {
-            return grid.GetFatBlocks().OfType<MyCockpit>().Any(b => b.Pilot != null);
+            return grid.GetFatBlocks().OfType<MyShipController>().Any(b => b.Pilot != null);
         }
 
         /// <summary>

--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -178,6 +178,9 @@ namespace Essentials.Commands
                 bool res = true;
                 foreach (var node in group.Nodes)
                 {
+                    if (node.NodeData.Projector != null)
+                        continue;
+                    
                     foreach (var c in conditions)
                     {
                         bool? r = c.Invoke(node.NodeData);
@@ -194,7 +197,7 @@ namespace Essentials.Commands
                 }
 
                 if(res)
-                    foreach (var grid in group.Nodes)
+                    foreach (var grid in group.Nodes.Where(x => x.NodeData.Projector == null))
                         yield return grid.NodeData;
             }
         }

--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -1,22 +1,16 @@
-﻿using System;
+﻿using NLog;
+using Sandbox.Game.Entities;
+using Sandbox.Game.EntityComponents;
+using Sandbox.Game.World;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Windows.Media.Media3D;
-using Sandbox.Game.Entities;
-using Sandbox.Game.World;
 using Torch.Commands;
-using NLog;
-using Sandbox.Game.EntityComponents;
-using Sandbox.Game.Multiplayer;
-using SpaceEngineers.Game.Entities.Blocks;
 using Torch.Mod;
 using Torch.Mod.Messages;
-using VRage.Game.Entity;
-using VRage.Game.ModAPI;
 using Vector3D = VRageMath.Vector3D;
 
 namespace Essentials.Commands
@@ -25,6 +19,7 @@ namespace Essentials.Commands
     public class CleanupModule : CommandModule
     {
         private static readonly Logger Log = LogManager.GetLogger("Essentials");
+
         [Command("scan", "Find grids matching the given conditions")]
         public void Scan()
         {
@@ -64,7 +59,7 @@ namespace Essentials.Commands
             Log.Info($"Cleanup deleted {count} grids matching conditions {string.Join(", ", Context.Args)}");
         }
 
-        [Command("delete floatingobjects","deletes floating objects")]
+        [Command("delete floatingobjects", "deletes floating objects")]
         public void FlObjDelete()
         {
             var count = 0;
@@ -76,7 +71,6 @@ namespace Essentials.Commands
             }
             Context.Respond($"Deleted {count} floating objects.");
             Log.Info($"Cleanup deleted {count} floating objects");
-
         }
 
         [Command("help", "Lists all cleanup conditions.")]
@@ -89,8 +83,8 @@ namespace Essentials.Commands
                 sb.AppendLine($"   {c.HelpText}");
             }
 
-            if(!Context.SentBySelf)
-            ModCommunication.SendMessageTo(new DialogMessage("Cleanup help", null, sb.ToString()), Context.Player.SteamUserId);
+            if (!Context.SentBySelf)
+                ModCommunication.SendMessageTo(new DialogMessage("Cleanup help", null, sb.ToString()), Context.Player.SteamUserId);
             else
                 Context.Respond(sb.ToString());
         }
@@ -116,8 +110,8 @@ namespace Essentials.Commands
         private IEnumerable<MyCubeGrid> ScanConditions(IReadOnlyList<string> args)
         {
             var conditions = new List<Func<MyCubeGrid, bool?>>();
-            
-            for (var i = 0; i < args.Count; i ++)
+
+            for (var i = 0; i < args.Count; i++)
             {
                 string parameter;
                 if (i + 1 >= args.Count)
@@ -130,7 +124,6 @@ namespace Essentials.Commands
                 }
 
                 var arg = args[i];
-                
 
                 if (parameter != null)
                 {
@@ -169,7 +162,7 @@ namespace Essentials.Commands
             }
 
             //default scan to find grids without pilots
-            if(!args.Contains("haspilot", StringComparer.CurrentCultureIgnoreCase))
+            if (!args.Contains("haspilot", StringComparer.CurrentCultureIgnoreCase))
                 conditions.Add(g => !Piloted(g));
 
             foreach (var group in MyCubeGridGroups.Static.Logical.Groups)
@@ -180,7 +173,7 @@ namespace Essentials.Commands
                 {
                     if (node.NodeData.Projector != null)
                         continue;
-                    
+
                     foreach (var c in conditions)
                     {
                         bool? r = c.Invoke(node.NodeData);
@@ -196,7 +189,7 @@ namespace Essentials.Commands
                         break;
                 }
 
-                if(res)
+                if (res)
                     foreach (var grid in group.Nodes.Where(x => x.NodeData.Projector == null))
                         yield return grid.NodeData;
             }
@@ -216,6 +209,18 @@ namespace Essentials.Commands
         public bool BlocksLessThan(MyCubeGrid grid, int count)
         {
             return grid.BlocksCount < count;
+        }
+
+        [Condition("pcugreaterthan", helpText: "Finds grids with more than the given number of PCU.")]
+        public bool PCUGreaterThan(MyCubeGrid grid, int pcu)
+        {
+            return grid.BlocksPCU > pcu;
+        }
+
+        [Condition("pculessthan", helpText: "Finds grids with less than the given number of PCU.")]
+        public bool PCULessThan(MyCubeGrid grid, int pcu)
+        {
+            return grid.BlocksPCU < pcu;
         }
 
         [Condition("blocksgreaterthan", helpText: "Finds grids with more than the given number of blocks.")]
@@ -299,9 +304,9 @@ namespace Essentials.Commands
                 var player = Utilities.GetPlayerByNameOrId(str);
                 if (player == null)
                 {
-                    if(long.TryParse(str, out long NPCId))
+                    if (long.TryParse(str, out long NPCId))
                     {
-                        if(MySession.Static.Players.IdentityIsNpc(NPCId))
+                        if (MySession.Static.Players.IdentityIsNpc(NPCId))
                         {
                             return grid.BigOwners.Contains(NPCId);
                         }
@@ -333,7 +338,7 @@ namespace Essentials.Commands
         }
 
         /// <summary>
-        /// Removes pilots from grid before deleting, 
+        /// Removes pilots from grid before deleting,
         /// so the character doesn't also get deleted and break everything
         /// </summary>
         /// <param name="grid"></param>
@@ -360,7 +365,7 @@ namespace Essentials.Commands
                 InvertCommand = attribute.InvertCommand;
                 HelpText = attribute.HelpText;
                 _method = evalMethod;
-                if(_method.ReturnType!= typeof(bool))
+                if (_method.ReturnType != typeof(bool))
                     throw new TypeLoadException("Condition does not return a bool!");
                 var p = _method.GetParameters();
                 if (p.Length < 1 || p[0].ParameterType != typeof(MyCubeGrid))
@@ -371,7 +376,6 @@ namespace Essentials.Commands
                     Parameter = null;
                 else
                     Parameter = p[1];
-
             }
 
             public bool? Evaluate(MyCubeGrid grid, string arg, bool invert, CleanupModule module)
@@ -396,13 +400,13 @@ namespace Essentials.Commands
                         return null;
                     }
 
-                    result = (bool)_method.Invoke(module, new[] {grid, val});
+                    result = (bool)_method.Invoke(module, new[] { grid, val });
                 }
                 else
                 {
-                    result = (bool)_method.Invoke(module, new object[] {grid});
+                    result = (bool)_method.Invoke(module, new object[] { grid });
                 }
-                
+
                 return result != invert;
             }
         }

--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -223,6 +223,37 @@ namespace Essentials.Commands
             return grid.BlocksPCU < pcu;
         }
 
+        [Condition("hasownertype", helpText: "Finds grids with the specified owner type (npc | player | nobody).")]
+        public bool HasOwnerType(MyCubeGrid grid, string ownerType)
+        {
+            if (string.IsNullOrEmpty(ownerType))
+                return false;
+
+            // Get the owner type of the grid.
+            var gridOwnerType = Utils.Ownership.GetOwnerType(grid);
+
+            // Check provided input string.
+            switch (ownerType.ToLower().Trim())
+            {
+                // Check if grid is owner by an NPC.
+                case "npc":
+                case "npcs":
+                    return gridOwnerType == Utils.Ownership.OwnerType.NPC;
+
+                // Check if the grid is owned by a Player.
+                case "player":
+                case "players":
+                    return gridOwnerType == Utils.Ownership.OwnerType.Player;
+
+                // Check if the grid is owned by Nobody.
+                case "nobody":
+                    return gridOwnerType == Utils.Ownership.OwnerType.Nobody;
+            }
+
+            // In all other cases, just return false.
+            return false;
+        }
+
         [Condition("blocksgreaterthan", helpText: "Finds grids with more than the given number of blocks.")]
         public bool BlocksGreaterThan(MyCubeGrid grid, int count)
         {

--- a/Essentials/Commands/EcoModule.cs
+++ b/Essentials/Commands/EcoModule.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Timers;
+using Sandbox;
+using Sandbox.Engine.Multiplayer;
+using Sandbox.Game.GameSystems.BankingAndCurrency;
+using Sandbox.Game.World;
+using Torch;
+using Torch.API.Managers;
+using Torch.Commands;
+using Torch.Commands.Permissions;
+using Torch.Managers.ChatManager;
+using Torch.Mod;
+using Torch.Mod.Messages;
+using VRage.Game.ModAPI;
+using VRageRender.Utils;
+
+namespace Essentials.Commands
+{
+    [Category("econ")]
+    public class EcoModule : CommandModule {
+        [Command("give", "Add a specified anount of credits into a users account. Use '*' to affect all players")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void EcoGive(string Player, long amount) {
+            if (Player != "*") {
+                var p = Utilities.GetPlayerByNameOrId(Player);
+                if (p == null) {
+                    Context.Respond("Player not found");
+                    return;
+                }
+                p.TryGetBalanceInfo(out long balance);
+                Context.Respond($"new bal will be {balance + amount}");
+                p.RequestChangeBalance(amount);
+                ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been added to your virtual account", 10000, "Blue"), p.SteamUserId);
+
+            }
+            else {
+                foreach (var p in MySession.Static.Players.GetAllPlayers()) {
+                    long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
+                    MyBankingSystem.RequestBalanceChange(IdentityID, amount);
+                    ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been added to your virtual account", 10000, "Blue"), p.SteamId);
+                }
+            }
+            Context.Respond($"{amount} credits given to account(s)");
+        }
+
+        [Command("take", "Take a specified anount of credits from a users account. Use '*' to affect all players")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void EcoTake(string Player, long amount) {
+            if (Player != "*") {
+                var p = Utilities.GetPlayerByNameOrId(Player);
+                if (p == null) {
+                    Context.Respond("Player not found");
+                    return;
+                }
+                long changefactor = 0 - amount;
+                p.RequestChangeBalance(changefactor);
+                ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been taken to your virtual account", 10000, "Blue"), p.SteamUserId);
+            }
+            else {
+                foreach (var p in MySession.Static.Players.GetAllPlayers()) {
+                    long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
+                    long balance = MyBankingSystem.GetBalance(IdentityID);
+                    MyBankingSystem.RequestBalanceChange(IdentityID, -amount);
+                    ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been taken to your virtual account", 10000, "Blue"), p.SteamId);
+                }
+            }
+            Context.Respond($"{amount} credits taken from account(s)");
+        }
+
+        [Command("set", "Set a users account to a specifed balance. Use '*' to affect all players")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void EcoSet(string Player, long amount) {
+            if (Player != "*") {
+                var p = Utilities.GetPlayerByNameOrId(Player);
+                if (p == null) {
+                    Context.Respond("Player not found");
+                    return;
+                }
+                p.TryGetBalanceInfo(out long balance);
+                long difference = (balance - amount);
+                p.RequestChangeBalance(-difference);
+                ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been set to {amount} credits!", 10000, "Blue"), p.SteamUserId);
+            }
+            else {
+                foreach (var p in MySession.Static.Players.GetAllPlayers()) {
+                    long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
+                    long balance = MyBankingSystem.GetBalance(IdentityID);
+                    long difference = (balance - amount);
+                    MyBankingSystem.RequestBalanceChange(IdentityID, -difference);
+                    ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been set to {amount} credits!", 10000, "Blue"), p.SteamId);
+                }
+            }
+            Context.Respond($"Balance(s) set to {amount}");
+        }
+
+        [Command("reset", "Reset the credits in a users account to 10,000. Use '*' to affect all players")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void EcoReset(string Player) {
+            if (Player != "*") {
+                var p = Utilities.GetPlayerByNameOrId(Player);
+                if (p == null) {
+                    Context.Respond("Player not found");
+                    return;
+                }
+                p.TryGetBalanceInfo(out long balance);
+                long difference = (balance - 10000);
+                p.RequestChangeBalance(-difference);
+                ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been reset to 10,000 credits!", 10000, "Blue"), p.SteamUserId);
+            }
+            else {
+                foreach (var p in MySession.Static.Players.GetAllPlayers()) {
+                    long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
+                    long balance = MyBankingSystem.GetBalance(IdentityID);
+                    long difference = (balance - 10000);
+                    MyBankingSystem.RequestBalanceChange(IdentityID, -difference);
+                    ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been reset to 10,000 credits!", 10000, "Blue"), p.SteamId);
+                }
+            }
+            Context.Respond("Balance(s) reset to 10,000 credits");
+        }
+
+        [Command("top", "Return a list of each players balance on the server sorted from highest to lowest")]
+        [Permission(MyPromoteLevel.None)]
+        public void EcoTop() {
+            StringBuilder ecodata = new StringBuilder();
+            ecodata.AppendLine("Summary of balanaces accross the server");
+            Dictionary<ulong, long> balances = new Dictionary<ulong, long>();
+            foreach (var p in MySession.Static.Players.GetAllPlayers()) {
+                long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
+                long balance = MyBankingSystem.GetBalance(IdentityID);
+                balances.Add(p.SteamId, balance);
+            }
+            var sorted = balances.OrderByDescending(x => x.Value).ThenBy(x => x.Key);
+            foreach (var value in sorted) {
+                var test = MySession.Static.Players.TryGetIdentityNameFromSteamId(value.Key);
+                ecodata.AppendLine($"Player: {MySession.Static.Players.TryGetIdentityNameFromSteamId(value.Key).ToString()} - Balance: {value.Value.ToString()}");
+            }
+
+            if (Context.Player == null) {
+                Context.Respond(ecodata.ToString());
+                return;
+            }
+            ModCommunication.SendMessageTo(new DialogMessage("Public balance list", "List of players and their credit balances", ecodata.ToString()), Context.Player.SteamUserId);
+        }
+
+        [Command("check", "Check the balance of a specific player")]
+        [Permission(MyPromoteLevel.None)]
+        public void EcoCheck(string Player) {
+            var p = Utilities.GetPlayerByNameOrId(Player);
+            if (p == null) {
+                Context.Respond("Player is not online or cannot be found!");
+                return;
+            }
+            long balance = MyBankingSystem.GetBalance(p.Identity.IdentityId);
+            Context.Respond($"{p.DisplayName}'s balance is {balance} credits");
+        }
+
+        [Command("pay")]
+        [Permission(MyPromoteLevel.None)]
+        public void EcoPay(string Player, long amount) {
+            if (Context.Player == null) {
+                Context.Respond("Console cannot execute this command");
+                return;
+            }
+            var p = Utilities.GetPlayerByNameOrId(Player);
+            if (p == null) {
+                Context.Respond("Player is not online or cannot be found!");
+                return;
+            }
+            MyBankingSystem.RequestTransfer(Context.Player.Identity.IdentityId, p.IdentityId, amount);
+            ModCommunication.SendMessageTo(new NotificationMessage($"Your have recieved {amount} credits from {Context.Player}!", 10000, "Blue"),p.SteamUserId);
+            ModCommunication.SendMessageTo(new NotificationMessage($"Your have sent {amount} credits to {p.DisplayName}!", 10000, "Blue"),Context.Player.SteamUserId);
+        }
+
+    }
+}

--- a/Essentials/Commands/EcoModule.cs
+++ b/Essentials/Commands/EcoModule.cs
@@ -172,6 +172,8 @@ namespace Essentials.Commands
                 return;
             }
             MyBankingSystem.RequestTransfer(Context.Player.Identity.IdentityId, p.IdentityId, amount);
+            ModCommunication.SendMessageTo(new NotificationMessage($"Your have recieved {amount} credits from {Context.Player}!", 10000, "Blue"),p.SteamUserId);
+            ModCommunication.SendMessageTo(new NotificationMessage($"Your have sent {amount} credits to {p.DisplayName}!", 10000, "Blue"),Context.Player.SteamUserId);
         }
 
     }

--- a/Essentials/Commands/EcoModule.cs
+++ b/Essentials/Commands/EcoModule.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Timers;
+using Sandbox;
+using Sandbox.Engine.Multiplayer;
+using Sandbox.Game.GameSystems.BankingAndCurrency;
+using Sandbox.Game.World;
+using Torch;
+using Torch.API.Managers;
+using Torch.Commands;
+using Torch.Commands.Permissions;
+using Torch.Managers.ChatManager;
+using Torch.Mod;
+using Torch.Mod.Messages;
+using VRage.Game.ModAPI;
+using VRageRender.Utils;
+
+namespace Essentials.Commands
+{
+    [Category("econ")]
+    public class EcoModule : CommandModule {
+        [Command("give", "Add a specified anount of credits into a users account use '*' to affect all players")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void EcoGive(string Player, long amount) {
+            if (Player != "*") {
+                var p = Utilities.GetPlayerByNameOrId(Player);
+                if (p == null) {
+                    Context.Respond("Player not found");
+                    return;
+                }
+                p.TryGetBalanceInfo(out long balance);
+                Context.Respond($"new bal will be {balance + amount}");
+                p.RequestChangeBalance(amount);
+                ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been added to your virtual account", 10000, "Blue"), p.SteamUserId);
+
+            }
+            else {
+                foreach (var p in MySession.Static.Players.GetAllPlayers()) {
+                    long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
+                    MyBankingSystem.RequestBalanceChange(IdentityID, amount);
+                    ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been added to your virtual account", 10000, "Blue"), p.SteamId);
+                }
+            }
+            Context.Respond($"{amount} credits given to account(s)");
+        }
+
+        [Command("take", "Take a specified anount of credits from a users account use '*' to affect all players")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void EcoTake(string Player, long amount) {
+            if (Player != "*") {
+                var p = Utilities.GetPlayerByNameOrId(Player);
+                if (p == null) {
+                    Context.Respond("Player not found");
+                    return;
+                }
+                long changefactor = 0 - amount;
+                p.RequestChangeBalance(changefactor);
+                ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been taken to your virtual account", 10000, "Blue"), p.SteamUserId);
+            }
+            else {
+                foreach (var p in MySession.Static.Players.GetAllPlayers()) {
+                    long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
+                    long balance = MyBankingSystem.GetBalance(IdentityID);
+                    MyBankingSystem.RequestBalanceChange(IdentityID, -amount);
+                    ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been taken to your virtual account", 10000, "Blue"), p.SteamId);
+                }
+            }
+            Context.Respond($"{amount} credits taken from account(s)");
+        }
+
+        [Command("set", "Set a users account to a specifed balance use '*' to affect all players")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void EcoSet(string Player, long amount) {
+            if (Player != "*") {
+                var p = Utilities.GetPlayerByNameOrId(Player);
+                if (p == null) {
+                    Context.Respond("Player not found");
+                    return;
+                }
+                p.TryGetBalanceInfo(out long balance);
+                long difference = (balance - amount);
+                p.RequestChangeBalance(-difference);
+                ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been set to {amount} credits!", 10000, "Blue"), p.SteamUserId);
+            }
+            else {
+                foreach (var p in MySession.Static.Players.GetAllPlayers()) {
+                    long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
+                    long balance = MyBankingSystem.GetBalance(IdentityID);
+                    long difference = (balance - amount);
+                    MyBankingSystem.RequestBalanceChange(IdentityID, -difference);
+                    ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been set to {amount} credits!", 10000, "Blue"), p.SteamId);
+                }
+            }
+            Context.Respond($"Balance(s) set to {amount}");
+        }
+
+        [Command("reset", "Reset the credits in a users account to 10,000 use '*' to affect all players")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void EcoReset(string Player) {
+            if (Player != "*") {
+                var p = Utilities.GetPlayerByNameOrId(Player);
+                if (p == null) {
+                    Context.Respond("Player not found");
+                    return;
+                }
+                p.TryGetBalanceInfo(out long balance);
+                long difference = (balance - 10000);
+                p.RequestChangeBalance(-difference);
+                ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been reset to 10,000 credits!", 10000, "Blue"), p.SteamUserId);
+            }
+            else {
+                foreach (var p in MySession.Static.Players.GetAllPlayers()) {
+                    long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
+                    long balance = MyBankingSystem.GetBalance(IdentityID);
+                    long difference = (balance - 10000);
+                    MyBankingSystem.RequestBalanceChange(IdentityID, -difference);
+                    ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been reset to 10,000 credits!", 10000, "Blue"), p.SteamId);
+                }
+            }
+            Context.Respond("Balance(s) reset to 10,000 credits");
+        }
+
+        [Command("top", "Return a list of each players balance on the server sorted from highest to lowest")]
+        [Permission(MyPromoteLevel.None)]
+        public void EcoTop() {
+            StringBuilder ecodata = new StringBuilder();
+            ecodata.AppendLine("Summary of balanaces accross the server");
+            Dictionary<ulong, long> balances = new Dictionary<ulong, long>();
+            foreach (var p in MySession.Static.Players.GetAllPlayers()) {
+                long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
+                long balance = MyBankingSystem.GetBalance(IdentityID);
+                balances.Add(p.SteamId, balance);
+            }
+            var sorted = balances.OrderByDescending(x => x.Value).ThenBy(x => x.Key);
+            foreach (var value in sorted) {
+                var test = MySession.Static.Players.TryGetIdentityNameFromSteamId(value.Key);
+                ecodata.AppendLine($"Player: {MySession.Static.Players.TryGetIdentityNameFromSteamId(value.Key).ToString()} - Balance: {value.Value.ToString()}");
+            }
+
+            if (Context.Player == null) {
+                Context.Respond(ecodata.ToString());
+                return;
+            }
+            ModCommunication.SendMessageTo(new DialogMessage("Public balance list", "List of players and their credit balances", ecodata.ToString()), Context.Player.SteamUserId);
+        }
+
+        [Command("check", "Check the balance of a specific player")]
+        [Permission(MyPromoteLevel.None)]
+        public void EcoCheck(string Player) {
+            var p = Utilities.GetPlayerByNameOrId(Player);
+            if (p == null) {
+                Context.Respond("Player is not online or cannot be found!");
+                return;
+            }
+            long balance = MyBankingSystem.GetBalance(p.Identity.IdentityId);
+            Context.Respond($"{p.DisplayName}'s balance is {balance} credits");
+        }
+
+        [Command("pay")]
+        [Permission(MyPromoteLevel.None)]
+        public void EcoPay(string Player, long amount) {
+            if (Context.Player == null) {
+                Context.Respond("Console cannot execute this command");
+                return;
+            }
+            var p = Utilities.GetPlayerByNameOrId(Player);
+            if (p == null) {
+                Context.Respond("Player is not online or cannot be found!");
+                return;
+            }
+            MyBankingSystem.RequestTransfer(Context.Player.Identity.IdentityId, p.IdentityId, amount);
+        }
+
+    }
+}

--- a/Essentials/Commands/EcoModule.cs
+++ b/Essentials/Commands/EcoModule.cs
@@ -22,7 +22,7 @@ namespace Essentials.Commands
 {
     [Category("econ")]
     public class EcoModule : CommandModule {
-        [Command("give", "Add a specified anount of credits into a users account use '*' to affect all players")]
+        [Command("give", "Add a specified anount of credits into a users account. Use '*' to affect all players")]
         [Permission(MyPromoteLevel.Admin)]
         public void EcoGive(string Player, long amount) {
             if (Player != "*") {
@@ -47,7 +47,7 @@ namespace Essentials.Commands
             Context.Respond($"{amount} credits given to account(s)");
         }
 
-        [Command("take", "Take a specified anount of credits from a users account use '*' to affect all players")]
+        [Command("take", "Take a specified anount of credits from a users account. Use '*' to affect all players")]
         [Permission(MyPromoteLevel.Admin)]
         public void EcoTake(string Player, long amount) {
             if (Player != "*") {
@@ -71,7 +71,7 @@ namespace Essentials.Commands
             Context.Respond($"{amount} credits taken from account(s)");
         }
 
-        [Command("set", "Set a users account to a specifed balance use '*' to affect all players")]
+        [Command("set", "Set a users account to a specifed balance. Use '*' to affect all players")]
         [Permission(MyPromoteLevel.Admin)]
         public void EcoSet(string Player, long amount) {
             if (Player != "*") {
@@ -97,7 +97,7 @@ namespace Essentials.Commands
             Context.Respond($"Balance(s) set to {amount}");
         }
 
-        [Command("reset", "Reset the credits in a users account to 10,000 use '*' to affect all players")]
+        [Command("reset", "Reset the credits in a users account to 10,000. Use '*' to affect all players")]
         [Permission(MyPromoteLevel.Admin)]
         public void EcoReset(string Player) {
             if (Player != "*") {

--- a/Essentials/Commands/GridModule.cs
+++ b/Essentials/Commands/GridModule.cs
@@ -140,6 +140,7 @@ namespace Essentials
         public void StaticLarge()
         {
             foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(g => g.GridSizeEnum == MyCubeSize.Large).Where(x => x.Projector == null))
+                if (grid != grid.GetBiggestGridInGroup()) continue;
                 grid.OnConvertedToStationRequest(); //Keen why do you do this to me?
         }
 

--- a/Essentials/Commands/GridModule.cs
+++ b/Essentials/Commands/GridModule.cs
@@ -140,7 +140,6 @@ namespace Essentials
         public void StaticLarge()
         {
             foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(g => g.GridSizeEnum == MyCubeSize.Large).Where(x => x.Projector == null))
-                if (grid != grid.GetBiggestGridInGroup()) continue;
                 grid.OnConvertedToStationRequest(); //Keen why do you do this to me?
         }
 

--- a/Essentials/Commands/GridModule.cs
+++ b/Essentials/Commands/GridModule.cs
@@ -69,7 +69,7 @@ namespace Essentials
         [Permission(MyPromoteLevel.SpaceMaster)]
         public void StaticLarge()
         {
-            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(g => g.GridSizeEnum == MyCubeSize.Large))
+            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(g => g.GridSizeEnum == MyCubeSize.Large).Where(x => x.Projector == null))
                 grid.OnConvertedToStationRequest(); //Keen why do you do this to me?
         }
 
@@ -77,7 +77,7 @@ namespace Essentials
         [Permission(MyPromoteLevel.SpaceMaster)]
         public void StopAll()
         {
-                foreach (var grid in MyEntities.GetEntities().OfType<IMyCubeGrid>())
+                foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(x => x.Projector == null))
                 {
                     grid.Physics.ClearSpeed();
                 }
@@ -93,7 +93,7 @@ namespace Essentials
             foreach (var entity in MyEntities.GetEntities())
             {
                 var grid = entity as MyCubeGrid;
-                if (grid == null)
+                if (grid == null || grid.Projector != null)
                     continue;
 
                 if (grid.BigOwners.Contains(id))

--- a/Essentials/Commands/PlayerModule.cs
+++ b/Essentials/Commands/PlayerModule.cs
@@ -29,7 +29,12 @@ namespace Essentials
         [Permission(MyPromoteLevel.SpaceMaster)]
         public void Teleport(string entityToMove, string destination)
         {
-            Utilities.TryGetEntityByNameOrId(destination, out IMyEntity destEntity);
+
+            IMyEntity destEntity;
+            if (string.IsNullOrEmpty(destination))
+                destEntity = Context.Player?.Controller.ControlledEntity.Entity;
+            else
+                Utilities.TryGetEntityByNameOrId(destination, out destEntity);
 
             if (destEntity == null)
             {
@@ -62,6 +67,13 @@ namespace Essentials
         [Command("tpto", "Teleport directly to an another entity.")]
         [Permission(MyPromoteLevel.SpaceMaster)]
         public void TeleportTo(string destination, string entityToMove = null)
+        {
+            Teleport(entityToMove, destination);
+        }
+
+        [Command("tphere", "Teleport another entity directly to you.")]
+        [Permission(MyPromoteLevel.SpaceMaster)]
+        public void TeleportHere(string entityToMove, string destination = null) 
         {
             Teleport(entityToMove, destination);
         }

--- a/Essentials/Commands/VoxelModule.cs
+++ b/Essentials/Commands/VoxelModule.cs
@@ -30,30 +30,30 @@ namespace Essentials.Commands
             var voxelMaps = MyEntities.GetEntities().OfType<MyVoxelBase>();
             
             var resetIds = new List<long>();
-            //Parallel.ForEach(voxelMaps, map =>
-            foreach(var map in voxelMaps)
-                                        {
-                                            try
-                                            {
-                                                if (map.StorageName == null || map.Storage.DataProvider == null)
-                                                    continue;
+            
+            foreach (var map in voxelMaps)
+            {
+                try
+                {
+                    if (map.StorageName == null || map.Storage.DataProvider == null)
+                        continue;
 
-                                                long id = map.EntityId;
+                    long id = map.EntityId;
 
-                                                if(deleteStorage && map is MyVoxelMap)
-                                                    map.Close();
-                                                else
-                                                    map.Storage.Reset(MyStorageDataTypeFlags.All);
+                    if (deleteStorage && map is MyVoxelMap)
+                        map.Close();
+                    else
+                    {
+                        map.Storage.Reset(MyStorageDataTypeFlags.All);
+                        resetIds.Add(id);
+                    }
+                }
+                catch (Exception e)
+                {
+                    _log.Error($"{e.Message}\n{e.StackTrace}");
+                }
+            }
 
-                                                if(!deleteStorage)
-                                                    lock (resetIds)
-                                                        resetIds.Add(id);
-                                            }
-                                            catch (Exception e)
-                                            {
-                                                _log.Error($"{e.Message}\n{e.StackTrace}");
-                                            }
-                                        }//, blocking:true);
             ModCommunication.SendMessageToClients(new VoxelResetMessage(resetIds.ToArray()));
 
             Context.Respond($"Reset {resetIds.Count} voxel maps.");
@@ -66,38 +66,36 @@ namespace Essentials.Commands
 
             var resetIds = new List<long>();
 
-            //Parallel.ForEach(voxelMaps, map =>
-            foreach(var map in voxelMaps)
-                                        {
-                                            try
-                                            {
-                                                if (map.StorageName == null || map.Storage.DataProvider == null)
-                                                    continue;
+            foreach (var map in voxelMaps)
+            {
+                try
+                {
+                    if (map.StorageName == null || map.Storage.DataProvider == null)
+                        continue;
 
-                                                var s = map.PositionComp.WorldVolume;
-                                                var nearEntities = new List<MyEntity>();
+                    var s = map.PositionComp.WorldVolume;
+                    var nearEntities = new List<MyEntity>();
 
-                                                MyGamePruningStructure.GetAllTopMostEntitiesInSphere(ref s, nearEntities);
+                    MyGamePruningStructure.GetAllTopMostEntitiesInSphere(ref s, nearEntities);
 
-                                                if(nearEntities.Any(e => e is MyCubeGrid || e is MyCharacter))
-                                                    continue;
+                    if (nearEntities.Any(e => e is MyCubeGrid || e is MyCharacter))
+                        continue;
 
-                                                long id = map.EntityId;
+                    long id = map.EntityId;
 
-                                                if(deleteStorage)
-                                                    map.Close();
-                                                else
-                                                    map.Storage.Reset(MyStorageDataTypeFlags.All);
-
-                                                if(!deleteStorage)
-                                                    lock(resetIds)  
-                                                        resetIds.Add(id);
-                                            }
-                                            catch (Exception e)
-                                            {
-                                                _log.Error($"{e.Message}\n{e.StackTrace}");
-                                            }
-                                        }//);
+                    if (deleteStorage)
+                        map.Close();
+                    else
+                    {
+                        map.Storage.Reset(MyStorageDataTypeFlags.All);
+                        resetIds.Add(id);
+                    }
+                }
+                catch (Exception e)
+                {
+                    _log.Error($"{e.Message}\n{e.StackTrace}");
+                }
+            }
 
             ModCommunication.SendMessageToClients(new VoxelResetMessage(resetIds.ToArray()));
 
@@ -111,8 +109,7 @@ namespace Essentials.Commands
             var voxelMaps = MyEntities.GetEntities().OfType<MyVoxelMap>();
 
             var resetIds = new List<long>();
-
-            //Parallel.ForEach(voxelMaps, map =>
+            
             foreach (var map in voxelMaps)
             {
                 try
@@ -133,17 +130,16 @@ namespace Essentials.Commands
                     if(deleteStorage)
                         map.Close();
                     else
+                    {
                         map.Storage.Reset(MyStorageDataTypeFlags.All);
-
-                    if(!deleteStorage)
-                        lock (resetIds)
-                            resetIds.Add(id);
+                        resetIds.Add(id);
+                    }
                 }
                 catch (Exception e)
                 {
                     _log.Error($"{e.Message}\n{e.StackTrace}");
                 }
-            }//);
+            }
 
             ModCommunication.SendMessageToClients(new VoxelResetMessage(resetIds.ToArray()));
 
@@ -157,23 +153,21 @@ namespace Essentials.Commands
 
             var resetIds = new List<long>();
 
-            //Parallel.ForEach(voxelMaps, map =>
-            foreach(var map in voxelMaps)
-                                        {
-                                            try
-                                            {
-                                                if (map.StorageName == null || map.Storage.DataProvider == null)
-                                                    continue;
+            foreach (var map in voxelMaps)
+            {
+                try
+                {
+                    if (map.StorageName == null || map.Storage.DataProvider == null)
+                        continue;
 
-                                                map.Storage.Reset(MyStorageDataTypeFlags.All);
-                                                lock (resetIds)
-                                                    resetIds.Add(map.EntityId);
-                                            }
-                                            catch (Exception e)
-                                            {
-                                                _log.Error($"{e.Message}\n{e.StackTrace}");
-                                            }
-                                        }//);
+                    map.Storage.Reset(MyStorageDataTypeFlags.All);
+                    resetIds.Add(map.EntityId);
+                }
+                catch (Exception e)
+                {
+                    _log.Error($"{e.Message}\n{e.StackTrace}");
+                }
+            }
 
             ModCommunication.SendMessageToClients(new VoxelResetMessage(resetIds.ToArray()));
 

--- a/Essentials/Commands/WorldModule.cs
+++ b/Essentials/Commands/WorldModule.cs
@@ -91,6 +91,31 @@ namespace Essentials.Commands
             Context.Respond($"Removed {count} old identities and {count2} grids owned by them.");
         }
 
+        [Command("identity clear", "Clear identity of specific player")]
+        [Permission(MyPromoteLevel.Admin)]
+        public void PurgeIdentity (string playername) {
+            var count2 = 0;
+            var grids = MyEntities.GetEntities().OfType<MyCubeGrid>().ToList();
+            var idents = MySession.Static.Players.GetAllIdentities().ToList();
+            foreach (var identity in idents) {
+                if (identity.DisplayName == playername) {
+                    //MySession.Static.Factions.KickPlayerFromFaction(identity.IdentityId);
+                    RemoveFromFaction_Internal(identity);
+                    MySession.Static.Players.RemoveIdentity(identity.IdentityId);
+                    foreach (var grid in grids) {
+                        if (grid.BigOwners.Contains(identity.IdentityId)) {
+                            grid.Close();
+                            count2++;
+                        }
+                    }
+                }
+            }
+
+            RemoveEmptyFactions();
+            FixBlockOwnership();
+            Context.Respond($"Removed identity and {count2} grids owned by them.");
+        }
+
         [Command("rep wipe", "Resets the reputation on the server")]
         public void WipeReputation(bool removePlayerToFaction = true, bool removeFactionToFaction = true)
         {

--- a/Essentials/Commands/WorldModule.cs
+++ b/Essentials/Commands/WorldModule.cs
@@ -91,6 +91,14 @@ namespace Essentials.Commands
             Context.Respond($"Removed {count} old identities and {count2} grids owned by them.");
         }
 
+        [Command("rep wipe", "Resets the reputation on the server")]
+        public void WipeReputation(bool removePlayerToFaction = true, bool removeFactionToFaction = true)
+        {
+            var count = WipeRep(removePlayerToFaction, removeFactionToFaction);
+            Context.Respond($"Wiped {count} reputations");
+        }
+
+
         [Command("faction clean", "Removes factions with fewer than the given number of players.")]
         public void CleanFactions(int memberCount = 1)
         {
@@ -316,6 +324,11 @@ namespace Essentials.Commands
             //clean up empty factions
             count += CleanFaction_Internal();
 
+            //cleanup reputations
+
+            count += CleanupReputations();
+
+
             //Keen, for the love of god why is everything about GPS internal.
             var playerGpss = GpsDicField.GetValue(MySession.Static.Gpss) as Dictionary<long, Dictionary<int, MyGps>>;
             foreach (var id in playerGpss.Keys)
@@ -368,5 +381,98 @@ namespace Essentials.Commands
 
             Context.Respond($"Removed {count} unnecessary elements.");
         }
+
+        [ReflectedGetter(Name = "m_relationsBetweenFactions", Type = typeof(MyFactionCollection))]
+        private static Func<MyFactionCollection, Dictionary<MyFactionCollection.MyRelatablePair, Tuple<MyRelationsBetweenFactions, int>>> _relationsGet;
+        [ReflectedGetter(Name = "m_relationsBetweenPlayersAndFactions", Type = typeof(MyFactionCollection))]
+        private static Func<MyFactionCollection, Dictionary<MyFactionCollection.MyRelatablePair, Tuple<MyRelationsBetweenFactions, int>>> _playerRelationsGet;
+
+        private static int WipeRep(bool removePlayerToFaction, bool removeFactionToFaction)
+        {
+            var result = 0;
+            var collection0 = _relationsGet(MySession.Static.Factions);
+            var collection1 = _playerRelationsGet(MySession.Static.Factions);
+
+            if (removeFactionToFaction)
+            {
+                foreach (var pair in collection0.Keys.ToList())
+                {
+                    collection0.Remove(pair);
+                    result++;
+                }
+            }
+
+            if (removePlayerToFaction)
+            {
+                foreach (var pair in collection1.Keys.ToList())
+                {
+                    collection1.Remove(pair);
+                    result++;
+                }
+            }
+
+            return result;
+
+        }
+        private static int CleanupReputations()
+        {
+            var collection = _relationsGet(MySession.Static.Factions);
+            var collection2 = _playerRelationsGet(MySession.Static.Factions);
+
+
+            var validIdentities = new HashSet<long>();
+
+            //find all identities owning a block
+            foreach (var entity in MyEntities.GetEntities())
+            {
+                var grid = entity as MyCubeGrid;
+                if (grid == null)
+                    continue;
+                validIdentities.UnionWith(grid.SmallOwners);
+            }
+
+
+            //find online identities
+            foreach (var online in MySession.Static.Players.GetOnlinePlayers())
+            {
+                validIdentities.Add(online.Identity.IdentityId);
+            }
+
+            foreach (var identity in MySession.Static.Players.GetAllIdentities().ToList())
+            {
+                if (MySession.Static.Players.IdentityIsNpc(identity.IdentityId))
+                {
+                    validIdentities.Add(identity.IdentityId);
+                }
+            }
+
+
+            //might not be necessary, but just in case
+            validIdentities.Remove(0);
+            var result = 0;
+
+            var collection0List = collection.Keys.ToList();
+            var collection1List = collection2.Keys.ToList();
+
+            foreach (var pair in collection0List)
+            {
+                if (validIdentities.Contains(pair.RelateeId1) && validIdentities.Contains(pair.RelateeId2))
+                    continue;
+                collection.Remove(pair);
+            }
+
+            foreach (var pair in collection1List)
+            {
+                if (validIdentities.Contains(pair.RelateeId1) && validIdentities.Contains(pair.RelateeId2))
+                    continue;
+                collection2.Remove(pair);
+            }
+            
+
+            //_relationsSet.Invoke(MySession.Static.Factions,collection);
+            //_playerRelationsSet.Invoke(MySession.Static.Factions,collection2);
+            return result;
+        }
+
     }
 }

--- a/Essentials/Commands/WorldModule.cs
+++ b/Essentials/Commands/WorldModule.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NLog;
 using Sandbox.Engine.Multiplayer;
+using Sandbox.Game;
 using Sandbox.Game.Entities;
 using Sandbox.Game.Entities.Character;
 using Sandbox.Game.Gui;
@@ -27,7 +28,6 @@ using Torch.API.Session;
 using VRage.Game;
 using VRage.Game.ModAPI;
 using VRage.Network;
-using Sandbox.Game;
 
 namespace Essentials.Commands
 {
@@ -213,7 +213,7 @@ namespace Essentials.Commands
             var fac = MySession.Static.Factions.GetPlayerFaction(identity.IdentityId);
             if (fac == null)
                 return false;
-
+ 
             /* 
              * VisualScriptLogicProvider takes care of removal of faction if last 
              * identity is kicked, and promotes the next player in line to Founder 
@@ -446,6 +446,12 @@ namespace Essentials.Commands
                 }
             }
 
+            //Add Factions with at least one member to valid identities
+            foreach (var faction in MySession.Static.Factions.Factions.Where(x=>x.Value.Members.Count > 0))
+            {
+                validIdentities.Add(faction.Key);
+            }
+
 
             //might not be necessary, but just in case
             validIdentities.Remove(0);
@@ -459,6 +465,7 @@ namespace Essentials.Commands
                 if (validIdentities.Contains(pair.RelateeId1) && validIdentities.Contains(pair.RelateeId2))
                     continue;
                 collection.Remove(pair);
+                result++;
             }
 
             foreach (var pair in collection1List)
@@ -466,6 +473,7 @@ namespace Essentials.Commands
                 if (validIdentities.Contains(pair.RelateeId1) && validIdentities.Contains(pair.RelateeId2))
                     continue;
                 collection2.Remove(pair);
+                result++;
             }
             
 

--- a/Essentials/Commands/WorldModule.cs
+++ b/Essentials/Commands/WorldModule.cs
@@ -27,6 +27,7 @@ using Torch.API.Session;
 using VRage.Game;
 using VRage.Game.ModAPI;
 using VRage.Network;
+using Sandbox.Game;
 
 namespace Essentials.Commands
 {
@@ -204,7 +205,16 @@ namespace Essentials.Commands
             var fac = MySession.Static.Factions.GetPlayerFaction(identity.IdentityId);
             if (fac == null)
                 return false;
-            fac.KickMember(identity.IdentityId);
+
+            /* 
+             * VisualScriptLogicProvider takes care of removal of faction if last 
+             * identity is kicked, and promotes the next player in line to Founder 
+             * if the founder is being kicked. 
+             * 
+             * Factions must have a founder otherwise calls like MyFaction.Members.Keys will NRE. 
+             */
+            MyVisualScriptLogicProvider.KickPlayerFromFaction(identity.IdentityId);
+
             return true;
         }
         

--- a/Essentials/Essentials.csproj
+++ b/Essentials/Essentials.csproj
@@ -136,6 +136,7 @@
     </Compile>
     <Compile Include="AutoCommand.cs" />
     <Compile Include="AutoCommands.cs" />
+    <Compile Include="Commands\EcoModule.cs" />
     <Compile Include="Commands\VotingModule.cs" />
     <Compile Include="Commands\AdminModule.cs" />
     <Compile Include="Commands\BlocksModule.cs" />

--- a/Essentials/Essentials.csproj
+++ b/Essentials/Essentials.csproj
@@ -150,6 +150,7 @@
     <Compile Include="EssentialsPlugin.cs" />
     <Compile Include="Commands\GridModule.cs" />
     <Compile Include="Commands\PlayerModule.cs" />
+    <Compile Include="GridFinder.cs" />
     <Compile Include="InfoCommand.cs" />
     <Compile Include="Commands\InfoModule.cs" />
     <Compile Include="Patches\SessionDownloadPatch.cs" />

--- a/Essentials/Essentials.csproj
+++ b/Essentials/Essentials.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Patches\SessionDownloadPatch.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utilities.cs" />
+    <Compile Include="Utils\Ownership.cs" />
     <Compile Include="Utils\TypedObjectPool.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Essentials/GridFinder.cs
+++ b/Essentials/GridFinder.cs
@@ -1,0 +1,100 @@
+﻿using Sandbox.Game.Entities;
+using Sandbox.Game.Entities.Character;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using VRage.Game.ModAPI;
+using VRage.Groups;
+using VRageMath;
+
+namespace Essentials
+{
+    public class GridFinder 
+    {
+        public static ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> FindGridGroupMechanical(string gridName) 
+        {
+            var groups = new ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group>();
+
+            Parallel.ForEach(MyCubeGridGroups.Static.Mechanical.Groups, group => 
+            {
+                foreach (MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Node groupNodes in group.Nodes) 
+                {
+                    var grid = groupNodes.NodeData;
+
+                    if (grid.Physics == null)
+                        continue;
+
+                    /* Gridname is wrong ignore */
+                    if (!grid.DisplayName.Equals(gridName) && grid.EntityId + "" != gridName)
+                        continue;
+
+                    groups.Add(group);
+                }
+            });
+
+            return groups;
+        }
+
+        public static ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group> FindLookAtGridGroupMechanical(IMyCharacter controlledEntity) 
+        {
+            const float range = 5000;
+            Matrix worldMatrix;
+            Vector3D startPosition;
+            Vector3D endPosition;
+
+            worldMatrix = controlledEntity.GetHeadMatrix(true, true, false); // dead center of player cross hairs, or the direction the player is looking with ALT.
+            startPosition = worldMatrix.Translation + worldMatrix.Forward * 0.5f;
+            endPosition = worldMatrix.Translation + worldMatrix.Forward * (range + 0.5f);
+
+            var list = new Dictionary<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group, double>();
+            var ray = new RayD(startPosition, worldMatrix.Forward);
+
+            foreach (var group in MyCubeGridGroups.Static.Mechanical.Groups) 
+            {
+                foreach (MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Node groupNodes in group.Nodes) 
+                {
+                    IMyCubeGrid cubeGrid = groupNodes.NodeData;
+
+                    if (cubeGrid == null || cubeGrid.Physics == null)
+                        continue;
+
+                    // check if the ray comes anywhere near the Grid before continuing.    
+                    if (!ray.Intersects(cubeGrid.WorldAABB).HasValue)
+                        continue;
+
+                    Vector3I? hit = cubeGrid.RayCastBlocks(startPosition, endPosition);
+
+                    if (!hit.HasValue)
+                        continue;
+
+                    double distance = (startPosition - cubeGrid.GridIntegerToWorld(hit.Value)).Length();
+
+                    if (list.TryGetValue(group, out double oldDistance)) 
+                    {
+                        if (distance < oldDistance) 
+                        {
+                            list.Remove(group);
+                            list.Add(group, distance);
+                        }
+                    } 
+                    else 
+                    {
+                        list.Add(group, distance);
+                    }
+                }
+            }
+
+            var bag = new ConcurrentBag<MyGroups<MyCubeGrid, MyGridMechanicalGroupData>.Group>();
+
+            if (list.Count == 0)
+                return bag;
+
+            // find the closest Entity.
+            var item = list.OrderBy(f => f.Value).First();
+            bag.Add(item.Key);
+
+            return bag;
+        }
+    }
+}

--- a/Essentials/Utils/Ownership.cs
+++ b/Essentials/Utils/Ownership.cs
@@ -1,0 +1,51 @@
+﻿using Sandbox.Game.Entities;
+using Sandbox.Game.World;
+
+namespace Essentials.Utils
+{
+    public class Ownership
+    {
+        /// <summary>
+        /// Get owner of the Grid.
+        /// </summary>
+        /// <param name="grid"></param>
+        /// <returns>Id of the owner</returns>
+        public static long GetOwner(MyCubeGrid grid)
+        {
+            if (grid.BigOwners.Count > 0 && grid.BigOwners[0] != 0)
+                return grid.BigOwners[0];
+            else if (grid.BigOwners.Count > 1)
+                return grid.BigOwners[1];
+            else
+                return 0L;
+        }
+
+        /// <summary>
+        /// Gets the type of the owner (NPC, Player or Nobody).
+        /// </summary>
+        /// <param name="grid"></param>
+        public static OwnerType GetOwnerType(MyCubeGrid grid)
+        {
+            // Get the owner id of the grid.
+            var ownerId = GetOwner(grid);
+
+            // Return the right owner type.
+            if (ownerId == 0L)
+                return OwnerType.Nobody;
+            else if (MySession.Static.Players.IdentityIsNpc(ownerId))
+                return OwnerType.NPC;
+            else
+                return OwnerType.Player;
+        }
+
+        /// <summary>
+        /// OwnerType Enumerator.
+        /// </summary>
+        public enum OwnerType
+        {
+            Nobody,
+            NPC,
+            Player
+        }
+    }
+}


### PR DESCRIPTION
      //Possible to add this to the CleanupModule.cs ?  

        [Command("delete offtype", "Deletes grids with specified blocks toggled off.")]
        public void OffType(string type)
        {
            var count = 0;
            foreach (var grid in MyEntities.GetEntities().OfType<MyCubeGrid>().Where(x => x.Projector == null))
            {
                foreach (var block in grid.GetFatBlocks().OfType<IMyFunctionalBlock>())
                {
                    var blockType = block.BlockDefinition.TypeId.ToString().Substring(16);
                    if (block != null && string.Compare(type, blockType, StringComparison.InvariantCultureIgnoreCase) ==
                        0)
                    {
                        if (block.IsWorking == false)
                        {
                            Log.Info($"Deleting grid: {grid.EntityId}: {grid.DisplayName}");
                            EjectPilots(grid);
                            grid.Close();
                            count++;
                        }
                    }
                }
            }


            Context.Respond($"grid delete {count} with off blocks of type {type}.");

        }