### PR TITLE
Fix Project-Settings, Fix Compile Errors and improvement for Cleanup for Offline Players and NPCs

### DIFF
--- a/Essentials.Tests/Essentials.Tests.csproj
+++ b/Essentials.Tests/Essentials.Tests.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.12\lib\net45\NLog.dll</HintPath>
+      <HintPath>$(SolutionDir)\TorchBinaries\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -339,7 +339,7 @@ namespace Essentials.Commands
             }
             else
             {
-                var player = Utilities.GetPlayerByNameOrId(str);
+                var player = Utilities.GetIdentityByNameOrIds(str);
                 if (player == null)
                 {
                     if (long.TryParse(str, out long NPCId))

--- a/Essentials/Commands/EcoModule.cs
+++ b/Essentials/Commands/EcoModule.cs
@@ -40,7 +40,7 @@ namespace Essentials.Commands
             else {
                 foreach (var p in MySession.Static.Players.GetAllPlayers()) {
                     long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
-                    MyBankingSystem.RequestBalanceChange(IdentityID, amount);
+                    MyBankingSystem.ChangeBalance(IdentityID, amount);
                     ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been added to your virtual account", 10000, "Blue"), p.SteamId);
                 }
             }
@@ -64,7 +64,7 @@ namespace Essentials.Commands
                 foreach (var p in MySession.Static.Players.GetAllPlayers()) {
                     long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
                     long balance = MyBankingSystem.GetBalance(IdentityID);
-                    MyBankingSystem.RequestBalanceChange(IdentityID, -amount);
+                    MyBankingSystem.ChangeBalance(IdentityID, -amount);
                     ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been taken to your virtual account", 10000, "Blue"), p.SteamId);
                 }
             }
@@ -90,7 +90,7 @@ namespace Essentials.Commands
                     long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
                     long balance = MyBankingSystem.GetBalance(IdentityID);
                     long difference = (balance - amount);
-                    MyBankingSystem.RequestBalanceChange(IdentityID, -difference);
+                    MyBankingSystem.ChangeBalance(IdentityID, -difference);
                     ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been set to {amount} credits!", 10000, "Blue"), p.SteamId);
                 }
             }
@@ -116,7 +116,7 @@ namespace Essentials.Commands
                     long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
                     long balance = MyBankingSystem.GetBalance(IdentityID);
                     long difference = (balance - 10000);
-                    MyBankingSystem.RequestBalanceChange(IdentityID, -difference);
+                    MyBankingSystem.ChangeBalance(IdentityID, -difference);
                     ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been reset to 10,000 credits!", 10000, "Blue"), p.SteamId);
                 }
             }

--- a/Essentials/Essentials.csproj
+++ b/Essentials/Essentials.csproj
@@ -33,7 +33,7 @@
       <HintPath>..\GameBinaries\netstandard.dll</HintPath>
     </Reference>
     <Reference Include="NLog">
-      <HintPath>..\packages\NLog.4.4.12\lib\net45\NLog.dll</HintPath>
+      <HintPath>$(SolutionDir)\TorchBinaries\NLog.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="PresentationCore" />

--- a/Essentials/Utilities.cs
+++ b/Essentials/Utilities.cs
@@ -52,6 +52,28 @@ namespace Essentials
             return false;
         }
 
+        public static IMyIdentity GetIdentityByNameOrIds(string playerNameOrIds) 
+        {
+            foreach (var identity in MySession.Static.Players.GetAllIdentities()) 
+            {
+                if (identity.DisplayName == playerNameOrIds)
+                    return identity;
+
+                if (long.TryParse(playerNameOrIds, out long identityId)) 
+                    if (identity.IdentityId == identityId)
+                        return identity;
+
+                if (ulong.TryParse(playerNameOrIds, out ulong steamId)) 
+                {
+                    ulong id = MySession.Static.Players.TryGetSteamId(identity.IdentityId);
+                    if (id == steamId)
+                        return identity;
+                }
+            }
+
+            return null;
+        }
+
         public static IMyPlayer GetPlayerByNameOrId(string nameOrPlayerId)
         {
             if (!long.TryParse(nameOrPlayerId, out long id))


### PR DESCRIPTION
As the title sais, NLog.dll was referenced to whatever location but not using the TorchBinaries. So on my system it didnt work.

Keen renamed RequestBalanceChange to ChangeBalance which is broken in the current version (about all !econ commands)

And !cleanup list ownedby did ignore NPC names, or names of offline players which is not so great. 