### PR TITLE
added hasgridtype condition

### DIFF
--- a/Essentials/Commands/CleanupModule.cs
+++ b/Essentials/Commands/CleanupModule.cs
@@ -223,6 +223,28 @@ namespace Essentials.Commands
             return grid.BlocksPCU < pcu;
         }
 
+        [Condition("hasgridtype", helpText: "Finds grids with the specified grid type (large | small | ship | static).")]
+        public bool HasGridType(MyCubeGrid grid, string gridType) 
+        {
+            if (string.IsNullOrEmpty(gridType))
+                return false;
+
+            if (string.Compare(gridType, "static", StringComparison.InvariantCultureIgnoreCase) == 0)
+                return grid.IsStatic;
+
+            if (string.Compare(gridType, "ship", StringComparison.InvariantCultureIgnoreCase) == 0) 
+                return !grid.IsStatic;
+
+            if (string.Compare(gridType, "large", StringComparison.InvariantCultureIgnoreCase) == 0)
+                return grid.GridSizeEnum == VRage.Game.MyCubeSize.Large;
+
+            if (string.Compare(gridType, "small", StringComparison.InvariantCultureIgnoreCase) == 0) 
+                return grid.GridSizeEnum == VRage.Game.MyCubeSize.Small;
+
+            // In all other cases, just return false.
+            return false;
+        }
+
         [Condition("hasownertype", helpText: "Finds grids with the specified owner type (npc | player | nobody).")]
         public bool HasOwnerType(MyCubeGrid grid, string ownerType)
         {


### PR DESCRIPTION
When using !cleanup delete hasownertype npc everything will be deleted that is npc owned, so stations and ships. This is not a good behavior as NPC stations that are protected by safezoned may not want to be deleted.

You of course can remove them and use the shitty commands to remove the now empty safezones as well but players may want to expect a consistent location of these NPCs, as common points of interest.

So with this new condition you can
!cleanup delete hasownertype npc hasgridtype ship
which will only remove npc ships and leave the stations.

Similar to all other conditions a grid will only be deleted if all subgrids match this condition. So it works best for ships, as all subgrids of a ship usually are ships as well. However a station with a rotor head wont be removed by "static" condition as long as the rotor head is there.

This could be changed in the future but personally I dont think its needed to build something inconsistent there.