### PR TITLE
fix nullpo player login & move "KnownSteamIds" to a separate file 

### DIFF
--- a/Essentials/Essentials.csproj
+++ b/Essentials/Essentials.csproj
@@ -163,6 +163,7 @@
     <Compile Include="GridFinder.cs" />
     <Compile Include="InfoCommand.cs" />
     <Compile Include="Commands\InfoModule.cs" />
+    <Compile Include="KnownIdsStorage.cs" />
     <Compile Include="Patches\ChatMessagePatch.cs" />
     <Compile Include="Patches\SessionDownloadPatch.cs" />
     <Compile Include="PlayerAccountModule.cs" />

--- a/Essentials/EssentialsConfig.cs
+++ b/Essentials/EssentialsConfig.cs
@@ -23,7 +23,6 @@ namespace Essentials
         public EssentialsConfig()
         {
             AutoCommands.CollectionChanged += (sender, args) => OnPropertyChanged();
-            KnownSteamIds.CollectionChanged += (sender, args) => OnPropertyChanged();
             InfoCommands.CollectionChanged += (sender, args) => OnPropertyChanged();
         }
 
@@ -94,9 +93,6 @@ namespace Essentials
             get => _backpackLimit;
             set => SetValue(ref _backpackLimit, value);
         }
-
-        [Display(Visible=false)]
-        public ObservableCollection<ulong> KnownSteamIds { get; } = new ObservableCollection<ulong>();
 
         private bool _cutGameTags;
         [Display(Name = "Cut Game Tags", GroupName = "Client Join Tweaks", Order = 8, Description = "Cuts mods and blocks limits from matchmaking server info. Prevents from 'error downloading session settings'.")]

--- a/Essentials/EssentialsPlugin.cs
+++ b/Essentials/EssentialsPlugin.cs
@@ -54,7 +54,7 @@ namespace Essentials
         private HashSet<ulong> _motdOnce = new HashSet<ulong>();
         private PatchManager _pm;
         private PatchContext _context;
-     
+        private KnownIdsStorage _knownIds;
 
         public static EssentialsPlugin Instance { get; private set; }
         public PlayerAccountModule AccModule = new PlayerAccountModule();
@@ -77,6 +77,8 @@ namespace Essentials
             string path = Path.Combine(StoragePath, "Essentials.cfg");
             Log.Info($"Attempting to load config from {path}");
             _config = Persistent<EssentialsConfig>.Load(path);
+            _knownIds = new KnownIdsStorage(Path.Combine(StoragePath, "Essentials.KnownSteamIds.txt"));
+            _knownIds.Read();
             _sessionManager = Torch.Managers.GetManager<TorchSessionManager>();
             if (_sessionManager != null)
                 _sessionManager.SessionStateChanged += SessionChanged;
@@ -304,10 +306,10 @@ namespace Essentials
             
             string name = player.Identity?.DisplayName ?? "player";
 
-            bool isNewUser = !Config.KnownSteamIds.Contains(id);
+            bool isNewUser = !_knownIds.Contains(id);
             if (isNewUser)
             {
-                Config.KnownSteamIds.Add(id);
+                _knownIds.Add(id);
             }
             
             if (!string.IsNullOrEmpty(Config.MotdUrl) && isNewUser && Config.NewUserMotdUrl)

--- a/Essentials/KnownIdsStorage.cs
+++ b/Essentials/KnownIdsStorage.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Essentials
+{
+    public sealed class KnownIdsStorage
+    {
+        readonly HashSet<ulong> _steamIds;
+        readonly string _filePath;
+
+        public KnownIdsStorage(string filePath)
+        {
+            _filePath = filePath;
+            _steamIds = new HashSet<ulong>();
+        }
+
+        public void Read()
+        {
+            if (!File.Exists(_filePath)) return;
+
+            _steamIds.Clear();
+            foreach (var line in File.ReadAllLines(_filePath))
+            {
+                if (ulong.TryParse(line.Trim(), out var steamId))
+                {
+                    _steamIds.Add(steamId);
+                }
+            }
+        }
+
+        public bool Contains(ulong steamId)
+        {
+            return _steamIds.Contains(steamId);
+        }
+
+        public void Add(ulong steamId)
+        {
+            if (_steamIds.Add(steamId))
+            {
+                var lines = _steamIds.Select(s => $"{s}");
+                File.WriteAllLines(_filePath, lines);
+            }
+        }
+    }
+}

--- a/Essentials/PlayerAccountModule.cs
+++ b/Essentials/PlayerAccountModule.cs
@@ -153,8 +153,8 @@ namespace Essentials {
                             Account.KnownIps.Add(ip.ToString());
                         }
 
-                        if (Account.IdentityID == 0L && Account.Player != string.Empty) {
-                            Account.IdentityID = Utilities.GetIdentityByNameOrIds(Account.Player).IdentityId;
+                        if (Account.IdentityID == 0L && !string.IsNullOrEmpty(Account.Player)) {
+                            Account.IdentityID = Utilities.GetIdentityByNameOrIds(Account.Player)?.IdentityId ?? 0L;
                             UpdatePlayerAccount(Account);
                         }
                         found = true;


### PR DESCRIPTION
1. Fixed the null reference exception error on player login which isn't harmful but was scary
2. moved "KnownSteamIds" from the config to a separate text file so I can better share the configs via git and stuff