### PR TITLE
Several Bugfixes in EcoCommands

### DIFF
--- a/Essentials/Commands/EcoModule.cs
+++ b/Essentials/Commands/EcoModule.cs
@@ -161,12 +161,12 @@ namespace Essentials.Commands
         [Command("check", "Check the balance of a specific player")]
         [Permission(MyPromoteLevel.None)]
         public void EcoCheck(string Player) {
-            var p = Utilities.GetPlayerByNameOrId(Player);
+            var p = Utilities.GetIdentityByNameOrIds(Player);
             if (p == null) {
-                Context.Respond("Player is not online or cannot be found!");
+                Context.Respond("Player cannot be found!");
                 return;
             }
-            long balance = MyBankingSystem.GetBalance(p.Identity.IdentityId);
+            long balance = MyBankingSystem.GetBalance(p.IdentityId);
             Context.Respond($"{p.DisplayName}'s balance is {balance:#,##0} credits");
         }
 

--- a/Essentials/Commands/EcoModule.cs
+++ b/Essentials/Commands/EcoModule.cs
@@ -195,7 +195,7 @@ namespace Essentials.Commands
             var finalToBalance = MyBankingSystem.GetBalance(toIdentitiyId) + amount;
             
             MyBankingSystem.RequestTransfer_BroadcastToClients(Context.Player.Identity.IdentityId, p.Identity.IdentityId, amount, finalFromBalance, finalToBalance);
-            ModCommunication.SendMessageTo(new NotificationMessage($"Your have recieved {amount:#,##0} credits from {Context.Player}!", 10000, "Blue"),p.SteamUserId);
+            ModCommunication.SendMessageTo(new NotificationMessage($"Your have recieved {amount:#,##0} credits from {Context.Player.DisplayName}!", 10000, "Blue"),p.SteamUserId);
             ModCommunication.SendMessageTo(new NotificationMessage($"Your have sent {amount:#,##0} credits to {p.DisplayName}!", 10000, "Blue"),Context.Player.SteamUserId);
         }
 

--- a/Essentials/Commands/EcoModule.cs
+++ b/Essentials/Commands/EcoModule.cs
@@ -130,9 +130,19 @@ namespace Essentials.Commands
             ecodata.AppendLine("Summary of balanaces accross the server");
             Dictionary<ulong, long> balances = new Dictionary<ulong, long>();
             foreach (var p in MySession.Static.Players.GetAllPlayers()) {
+
                 long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
                 long balance = MyBankingSystem.GetBalance(IdentityID);
-                balances.Add(p.SteamId, balance);
+
+                /*
+                 * Add or Update. We have seen that it is possible to have 
+                 * two players with the same SteamID but different SerialIDs.
+                 * 
+                 * Those also had different identities. But one of which was dead. 
+                 * TryGetIdentityId() Returned the same value in both cases. So no damage done if
+                 * Value is just overwritten.
+                 */
+                balances[p.SteamId] = balance;
             }
             var sorted = balances.OrderByDescending(x => x.Value).ThenBy(x => x.Key);
             foreach (var value in sorted) {

--- a/Essentials/Commands/EcoModule.cs
+++ b/Essentials/Commands/EcoModule.cs
@@ -22,6 +22,7 @@ namespace Essentials.Commands
 {
     [Category("econ")]
     public class EcoModule : CommandModule {
+
         [Command("give", "Add a specified anount of credits into a users account. Use '*' to affect all players")]
         [Permission(MyPromoteLevel.Admin)]
         public void EcoGive(string Player, long amount) {
@@ -32,19 +33,19 @@ namespace Essentials.Commands
                     return;
                 }
                 p.TryGetBalanceInfo(out long balance);
-                Context.Respond($"new bal will be {balance + amount}");
+                Context.Respond($"new bal will be {balance + amount:#,##0}");
                 p.RequestChangeBalance(amount);
-                ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been added to your virtual account", 10000, "Blue"), p.SteamUserId);
+                ModCommunication.SendMessageTo(new NotificationMessage($"{amount:#,##0} credits have been added to your virtual account", 10000, "Blue"), p.SteamUserId);
 
             }
             else {
                 foreach (var p in MySession.Static.Players.GetAllPlayers()) {
                     long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
                     MyBankingSystem.ChangeBalance(IdentityID, amount);
-                    ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been added to your virtual account", 10000, "Blue"), p.SteamId);
+                    ModCommunication.SendMessageTo(new NotificationMessage($"{amount:#,##0} credits have been added to your virtual account", 10000, "Blue"), p.SteamId);
                 }
             }
-            Context.Respond($"{amount} credits given to account(s)");
+            Context.Respond($"{amount:#,##0} credits given to account(s)");
         }
 
         [Command("take", "Take a specified anount of credits from a users account. Use '*' to affect all players")]
@@ -58,17 +59,17 @@ namespace Essentials.Commands
                 }
                 long changefactor = 0 - amount;
                 p.RequestChangeBalance(changefactor);
-                ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been taken to your virtual account", 10000, "Blue"), p.SteamUserId);
+                ModCommunication.SendMessageTo(new NotificationMessage($"{amount:#,##0} credits have been taken to your virtual account", 10000, "Blue"), p.SteamUserId);
             }
             else {
                 foreach (var p in MySession.Static.Players.GetAllPlayers()) {
                     long IdentityID = MySession.Static.Players.TryGetIdentityId(p.SteamId);
                     long balance = MyBankingSystem.GetBalance(IdentityID);
                     MyBankingSystem.ChangeBalance(IdentityID, -amount);
-                    ModCommunication.SendMessageTo(new NotificationMessage($"{amount} credits have been taken to your virtual account", 10000, "Blue"), p.SteamId);
+                    ModCommunication.SendMessageTo(new NotificationMessage($"{amount:#,##0} credits have been taken to your virtual account", 10000, "Blue"), p.SteamId);
                 }
             }
-            Context.Respond($"{amount} credits taken from account(s)");
+            Context.Respond($"{amount:#,##0} credits taken from account(s)");
         }
 
         [Command("set", "Set a users account to a specifed balance. Use '*' to affect all players")]
@@ -83,7 +84,7 @@ namespace Essentials.Commands
                 p.TryGetBalanceInfo(out long balance);
                 long difference = (balance - amount);
                 p.RequestChangeBalance(-difference);
-                ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been set to {amount} credits!", 10000, "Blue"), p.SteamUserId);
+                ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been set to {amount:#,##0} credits!", 10000, "Blue"), p.SteamUserId);
             }
             else {
                 foreach (var p in MySession.Static.Players.GetAllPlayers()) {
@@ -91,10 +92,10 @@ namespace Essentials.Commands
                     long balance = MyBankingSystem.GetBalance(IdentityID);
                     long difference = (balance - amount);
                     MyBankingSystem.ChangeBalance(IdentityID, -difference);
-                    ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been set to {amount} credits!", 10000, "Blue"), p.SteamId);
+                    ModCommunication.SendMessageTo(new NotificationMessage($"Your balance has been set to {amount:#,##0} credits!", 10000, "Blue"), p.SteamId);
                 }
             }
-            Context.Respond($"Balance(s) set to {amount}");
+            Context.Respond($"Balance(s) set to {amount:#,##0}");
         }
 
         [Command("reset", "Reset the credits in a users account to 10,000. Use '*' to affect all players")]
@@ -147,7 +148,7 @@ namespace Essentials.Commands
             var sorted = balances.OrderByDescending(x => x.Value).ThenBy(x => x.Key);
             foreach (var value in sorted) {
                 var test = MySession.Static.Players.TryGetIdentityNameFromSteamId(value.Key);
-                ecodata.AppendLine($"Player: {MySession.Static.Players.TryGetIdentityNameFromSteamId(value.Key).ToString()} - Balance: {value.Value.ToString()}");
+                ecodata.AppendLine($"Player: {MySession.Static.Players.TryGetIdentityNameFromSteamId(value.Key)} - Balance: {value.Value:#,##0}");
             }
 
             if (Context.Player == null) {
@@ -166,7 +167,7 @@ namespace Essentials.Commands
                 return;
             }
             long balance = MyBankingSystem.GetBalance(p.Identity.IdentityId);
-            Context.Respond($"{p.DisplayName}'s balance is {balance} credits");
+            Context.Respond($"{p.DisplayName}'s balance is {balance:#,##0} credits");
         }
 
         [Command("pay")]
@@ -186,8 +187,8 @@ namespace Essentials.Commands
             var finalToBalance = MyBankingSystem.GetBalance(p.Identity.IdentityId) + amount;
             
             MyBankingSystem.RequestTransfer_BroadcastToClients(Context.Player.Identity.IdentityId, p.Identity.IdentityId, amount, finalFromBalance, finalToBalance);
-            ModCommunication.SendMessageTo(new NotificationMessage($"Your have recieved {amount} credits from {Context.Player}!", 10000, "Blue"),p.SteamUserId);
-            ModCommunication.SendMessageTo(new NotificationMessage($"Your have sent {amount} credits to {p.DisplayName}!", 10000, "Blue"),Context.Player.SteamUserId);
+            ModCommunication.SendMessageTo(new NotificationMessage($"Your have recieved {amount:#,##0} credits from {Context.Player}!", 10000, "Blue"),p.SteamUserId);
+            ModCommunication.SendMessageTo(new NotificationMessage($"Your have sent {amount:#,##0} credits to {p.DisplayName}!", 10000, "Blue"),Context.Player.SteamUserId);
         }
 
     }

--- a/Essentials/Commands/EcoModule.cs
+++ b/Essentials/Commands/EcoModule.cs
@@ -182,9 +182,17 @@ namespace Essentials.Commands
                 Context.Respond("Player is not online or cannot be found!");
                 return;
             }
-            
-            var finalFromBalance = MyBankingSystem.GetBalance(Context.Player.Identity.IdentityId) - amount;
-            var finalToBalance = MyBankingSystem.GetBalance(p.Identity.IdentityId) + amount;
+
+            var fromIdentitiyId = Context.Player.Identity.IdentityId;
+            var toIdentitiyId = p.Identity.IdentityId;
+
+            if(fromIdentitiyId == toIdentitiyId) {
+                Context.Respond("You cannot pay yourself!");
+                return;
+            }
+
+            var finalFromBalance = MyBankingSystem.GetBalance(fromIdentitiyId) - amount;
+            var finalToBalance = MyBankingSystem.GetBalance(toIdentitiyId) + amount;
             
             MyBankingSystem.RequestTransfer_BroadcastToClients(Context.Player.Identity.IdentityId, p.Identity.IdentityId, amount, finalFromBalance, finalToBalance);
             ModCommunication.SendMessageTo(new NotificationMessage($"Your have recieved {amount:#,##0} credits from {Context.Player}!", 10000, "Blue"),p.SteamUserId);

--- a/Essentials/Commands/EcoModule.cs
+++ b/Essentials/Commands/EcoModule.cs
@@ -29,7 +29,7 @@ namespace Essentials.Commands
             if (Player != "*") {
                 var p = Utilities.GetPlayerByNameOrId(Player);
                 if (p == null) {
-                    Context.Respond("Player not found");
+                    Context.Respond("Player is not online or cannot be found!");
                     return;
                 }
                 p.TryGetBalanceInfo(out long balance);
@@ -54,7 +54,7 @@ namespace Essentials.Commands
             if (Player != "*") {
                 var p = Utilities.GetPlayerByNameOrId(Player);
                 if (p == null) {
-                    Context.Respond("Player not found");
+                    Context.Respond("Player is not online or cannot be found!");
                     return;
                 }
                 long changefactor = 0 - amount;
@@ -78,7 +78,7 @@ namespace Essentials.Commands
             if (Player != "*") {
                 var p = Utilities.GetPlayerByNameOrId(Player);
                 if (p == null) {
-                    Context.Respond("Player not found");
+                    Context.Respond("Player is not online or cannot be found!");
                     return;
                 }
                 p.TryGetBalanceInfo(out long balance);
@@ -104,7 +104,7 @@ namespace Essentials.Commands
             if (Player != "*") {
                 var p = Utilities.GetPlayerByNameOrId(Player);
                 if (p == null) {
-                    Context.Respond("Player not found");
+                    Context.Respond("Player is not online or cannot be found!");
                     return;
                 }
                 p.TryGetBalanceInfo(out long balance);


### PR DESCRIPTION
- Player cannot pay themselves anymore. This caused client and server to go out of sync, and cause crashes. Also it created money out of thin air.
- All Numbers are now formatted #,##0
- Fixed KeyAlreadyAddedException in Econ Top. 2 Players with same SteamID but different SerialID could break it. Assumption that it has something to do with perma death. The server I saw it on had 2 identities for that person too. One alive one dead. 
- !econ check can now also check for offline players. 
- !econ pay shows the correct playername in noticiation now instead of the MyPlayer toString()
- !econ give/set/take/reset now inform that the player might be offline.

The last four commands should also work with offline players. But this optimization is not "important" enough. So I didn't bother. 