### PR TITLE
Fix for wrong in-game whisper's format

### DIFF
--- a/Essentials/Commands/PlayerModule.cs
+++ b/Essentials/Commands/PlayerModule.cs
@@ -99,7 +99,7 @@ namespace Essentials
                 return;
             }
 
-            Context.Torch.CurrentSession?.Managers?.GetManager<IChatManagerServer>()?.SendMessageAsOther(message, Context.Player?.DisplayName ?? "Server", MyFontEnum.Red, player.SteamUserId);
+            Context.Torch.CurrentSession?.Managers?.GetManager<IChatManagerServer>()?.SendMessageAsOther(Context.Player?.DisplayName ?? "Server", message, MyFontEnum.Red, player.SteamUserId);
         }
 
         [Command("kick", "Kick a player from the game.")]


### PR DESCRIPTION
Like in title. Before this fix format was in wrong order. Message was on player's name part and player's name in message part (reported issue https://github.com/TorchAPI/Essentials/issues/214):
![354884518-0e76650b-8737-4427-b75c-0b15a0cb4736](https://github.com/user-attachments/assets/a615fdf2-e8e9-405a-824d-0799c8a8a89d)

After the fix order is correct:
![screenshot-31](https://github.com/user-attachments/assets/3cd2663d-bc75-4be2-8f0a-0ffd93dd53ba)
