### PR TITLE
Add "poweredgriddistancegreaterthan" cleanup filter.

### DIFF
--- a/Essentials/Conditions/ConditionsImplementations.cs
+++ b/Essentials/Conditions/ConditionsImplementations.cs
@@ -171,6 +171,21 @@ namespace Essentials.Commands
             return false;
         }
 
+        [Condition("poweredgriddistancegreaterthan", "Finds grids that are farther than the given distance from other grids that are powered.")]
+        public static bool PoweredGridDistanceGreaterThan(MyCubeGrid grid, double dist)
+        {
+            // Returns 'true' if the count of matched grids is zero for these conditions:
+            //        the distance from grid to entity is less than dist
+            //        the grid is unpowered
+            // Otherwise, returns 'false'
+            dist *= dist;
+            return MyEntities.GetEntities().Where(
+                x => 
+                (VRageMath.Vector3.DistanceSquared(x.PositionComp.GetPosition(), grid.PositionComp.GetPosition()) < dist 
+                && (x.GetType() == typeof(MyCubeGrid)))).Cast<MyCubeGrid>().Where(y => !y.EntityId.Equals(grid.EntityId) && !y.IsPowered)
+            .Count() == 0;           
+        }
+
         [Condition("centerdistancelessthan", "centerdistancegreaterthan", "Finds grids that are further than the given distance from center.")]
         public static bool CenterDistanceLessThan(MyCubeGrid grid, double dist)
         {

--- a/Essentials/Conditions/ConditionsImplementations.cs
+++ b/Essentials/Conditions/ConditionsImplementations.cs
@@ -174,15 +174,16 @@ namespace Essentials.Commands
         [Condition("poweredgriddistancegreaterthan", "Finds grids that are farther than the given distance from other grids that are powered.")]
         public static bool PoweredGridDistanceGreaterThan(MyCubeGrid grid, double dist)
         {
-            // Returns 'true' if the count of matched grids is zero for these conditions:
+            // Returns 'true' if the count of matched grids from a list of all grids is zero for these conditions:
             //        the distance from grid to entity is less than dist
-            //        the grid is unpowered
+            //        the grid is powered
             // Otherwise, returns 'false'
             dist *= dist;
             return MyEntities.GetEntities().Where(
                 x => 
                 (VRageMath.Vector3.DistanceSquared(x.PositionComp.GetPosition(), grid.PositionComp.GetPosition()) < dist 
-                && (x.GetType() == typeof(MyCubeGrid)))).Cast<MyCubeGrid>().Where(y => !y.EntityId.Equals(grid.EntityId) && !y.IsPowered)
+                    && (x.GetType() == typeof(MyCubeGrid))                
+                )).Cast<MyCubeGrid>().Where(y => !y.EntityId.Equals(grid.EntityId) && y.IsPowered)
             .Count() == 0;           
         }
 


### PR DESCRIPTION
This PR introduces a condition implementation for grids which are nearby another grid that is powered (excluding itself): "poweredgriddistancegreaterthan". On the server this was made for, cleanup conditions include:

"Must not have 'Grid' in the name"
"Must not have the starter ship name"
"Must have a beacon"

Grids not matching all of these conditions are removed. This can lead to some rather unfortunate situations with players starting builds at their base at the wrong time or with looting wrecks. A condition that checks for nearby powered grids would go significant lengths towards reducing the amount of 'oopsie' player grid deletions. 

Let the roast begin... ?